### PR TITLE
models: add Message field to JobDetails

### DIFF
--- a/pkg/models/job.go
+++ b/pkg/models/job.go
@@ -8,13 +8,22 @@ type (
 		Type string `json:"type"`
 	}
 
-	// JobDetails represents the job information.
+	// JobDetails represents the job information returned by job/get.json.
+	//
+	// Message is populated when the job has surfaced a top-level error
+	// or status message — typically present on state="Failed" and on
+	// some completed-but-noisy outcomes. It mirrors the API's
+	// `return.message` field and is the right place to read a
+	// human-friendly explanation of why a job failed (e.g. "Image not
+	// typed", "job already running on this stack"). Distinct from the
+	// per-step Logs entries.
 	JobDetails struct {
 		State     string `json:"state"`
 		Created   string `json:"created"`
 		Started   string `json:"started"`
 		Completed string `json:"completed"`
 		Logs      []Log  `json:"logs"`
+		Message   string `json:"message"`
 	}
 
 	// Log represents the logs attached to the JobDetails.


### PR DESCRIPTION
## Summary

The /job/get response includes a top-level \`message\` field used
by the API to surface failure reasons (and other status detail)
that aren't in \`output\`. The current \`models.JobDetails\` struct
silently drops it. This PR adds the field.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` clean
- [x] live-validated against a failed cloud-server-create job —
      message field carries the API's rejection reason where
      output is empty