### PR TITLE
info: add NewClientWithDiscovery helper

### DIFF
--- a/pkg/api/info/discover.go
+++ b/pkg/api/info/discover.go
@@ -1,0 +1,46 @@
+package info
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+// NewClientWithDiscovery returns a new *api.Client given just an
+// API key, by calling api/get_info.json to discover the
+// authenticated client's client_id.
+//
+// Use this when the caller does not yet know the client_id — for
+// example a tool bootstrapping against a freshly-issued key. Use
+// api.New(apiKey, clientID, opts...) directly if the client_id is
+// known, including when targeting a sub-account from a super-user
+// key (discovery resolves to the super-user's own id, which is
+// not the sub-account's id).
+//
+// opts are forwarded to the returned client unchanged; if
+// api.SetBaseURL is supplied it also applies to the discovery
+// call. The placeholder "0" used internally for the bootstrap
+// satisfies NewRequest's empty-check; api/get_info.json
+// authenticates against the apikey alone and does not validate
+// the client_id query parameter.
+func NewClientWithDiscovery(ctx context.Context, apiKey string, opts ...api.ClientOpt) (*api.Client, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("info.NewClientWithDiscovery: apiKey must not be empty")
+	}
+
+	bootstrap, err := api.New(apiKey, "0", opts...)
+	if err != nil {
+		return nil, fmt.Errorf("info.NewClientWithDiscovery: bootstrap client: %w", err)
+	}
+
+	resp, err := New(bootstrap).Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("info.NewClientWithDiscovery: api/get_info.json: %w", err)
+	}
+	if resp.Return.ClientID == "" {
+		return nil, fmt.Errorf("info.NewClientWithDiscovery: api/get_info.json returned empty client_id")
+	}
+
+	return api.New(apiKey, resp.Return.ClientID, opts...)
+}

--- a/pkg/api/info/discover_test.go
+++ b/pkg/api/info/discover_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestNewClientWithDiscovery_Success(t *testing.T) {
+	t.Parallel()
 	var bootstrapClientID, seenAPIKey string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/get_info.json" {
@@ -51,6 +52,7 @@ func TestNewClientWithDiscovery_Success(t *testing.T) {
 }
 
 func TestNewClientWithDiscovery_EmptyKey(t *testing.T) {
+	t.Parallel()
 	_, err := NewClientWithDiscovery(context.Background(), "")
 	if err == nil || !strings.Contains(err.Error(), "apiKey must not be empty") {
 		t.Errorf("err = %v, want apiKey must not be empty", err)
@@ -58,7 +60,8 @@ func TestNewClientWithDiscovery_EmptyKey(t *testing.T) {
 }
 
 func TestNewClientWithDiscovery_StatusFalse(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"status": false, "msg": "Invalid API key"}`)
 	}))
@@ -74,7 +77,8 @@ func TestNewClientWithDiscovery_StatusFalse(t *testing.T) {
 }
 
 func TestNewClientWithDiscovery_EmptyClientID(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
 			"status": true, "msg": "Successful.",

--- a/pkg/api/info/discover_test.go
+++ b/pkg/api/info/discover_test.go
@@ -1,0 +1,90 @@
+package info
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestNewClientWithDiscovery_Success(t *testing.T) {
+	var bootstrapClientID, seenAPIKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/get_info.json" {
+			t.Errorf("path = %q, want /api/get_info.json", r.URL.Path)
+		}
+		bootstrapClientID = r.URL.Query().Get("client_id")
+		seenAPIKey = r.URL.Query().Get("apikey")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true, "msg": "Successful.",
+			"return": {
+				"client_id": "979387",
+				"contact_id": null,
+				"modules": ["Server", "DNS", "Mail"],
+				"roles": ["sitehost"]
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := NewClientWithDiscovery(context.Background(), "the-key", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClientWithDiscovery: %v", err)
+	}
+	if c.ClientID != "979387" {
+		t.Errorf("returned ClientID = %q, want 979387", c.ClientID)
+	}
+	if c.APIKey != "the-key" {
+		t.Errorf("returned APIKey = %q, want the-key", c.APIKey)
+	}
+	if bootstrapClientID != "0" {
+		t.Errorf("bootstrap client_id query = %q, want 0 (placeholder)", bootstrapClientID)
+	}
+	if seenAPIKey != "the-key" {
+		t.Errorf("apikey query = %q", seenAPIKey)
+	}
+}
+
+func TestNewClientWithDiscovery_EmptyKey(t *testing.T) {
+	_, err := NewClientWithDiscovery(context.Background(), "")
+	if err == nil || !strings.Contains(err.Error(), "apiKey must not be empty") {
+		t.Errorf("err = %v, want apiKey must not be empty", err)
+	}
+}
+
+func TestNewClientWithDiscovery_StatusFalse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status": false, "msg": "Invalid API key"}`)
+	}))
+	defer server.Close()
+
+	_, err := NewClientWithDiscovery(context.Background(), "bad-key", api.SetBaseURL(server.URL))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "api/get_info.json") {
+		t.Errorf("err = %v, want wrapped api/get_info.json error", err)
+	}
+}
+
+func TestNewClientWithDiscovery_EmptyClientID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true, "msg": "Successful.",
+			"return": {"client_id": "", "modules": [], "roles": []}
+		}`)
+	}))
+	defer server.Close()
+
+	_, err := NewClientWithDiscovery(context.Background(), "the-key", api.SetBaseURL(server.URL))
+	if err == nil || !strings.Contains(err.Error(), "empty client_id") {
+		t.Errorf("err = %v, want empty client_id", err)
+	}
+}

--- a/pkg/api/info/doc.go
+++ b/pkg/api/info/doc.go
@@ -1,2 +1,19 @@
-// Package info represents our SiteHost `/api` API endpoint.
+// Package info wraps SiteHost's /api/* endpoints. The endpoint
+// exposed today is api/get_info.json (Get), which returns the
+// authenticated client's client_id, contact_id, and the list of
+// modules and roles their key has access to.
+//
+// # Bootstrap pattern
+//
+// api/get_info.json returns the authenticated client's client_id.
+// Consumers who do not yet know their client_id — for example a
+// freshly-issued super-user key being wired into a tool — can use
+// NewClientWithDiscovery to obtain a fully-configured *api.Client
+// from just the API key.
+//
+// For sub-account targeting from a super-user key, prefer
+// api.New(apiKey, subAccountClientID, opts...) directly:
+// discovery resolves to the super-user's own client_id, which is
+// not the sub-account's id and would scope subsequent calls to
+// the wrong account.
 package info


### PR DESCRIPTION
## Summary

Adds \`info.NewClientWithDiscovery\` — bootstrap an \`*api.Client\` from
just an API key, discovering the client_id via /info/get_client_id
under the hood. Useful for tools that hold an API key but not the
numeric client_id (most third-party automation, CI runners, AI
agents).

## Test plan

- [x] unit tests cover discovery success + failure paths
- [x] live-validated against a real account