### PR TITLE
redirect: new top-level package — list_redirects

### DIFF
--- a/examples/redirect/main.go
+++ b/examples/redirect/main.go
@@ -1,0 +1,54 @@
+// Program redirect is a read-only validation of
+// redirect.ListRedirects. Walks the nested map shape returned by
+// /redirect/list_redirects.json and prints every rule grouped by
+// domain.
+//
+// Required env: SH_API_KEY, SH_CLIENT_ID.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+	"github.com/sitehostnz/gosh/pkg/api/redirect"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("redirect: %v", err)
+	}
+}
+
+func run() error {
+	apiKey := os.Getenv("SH_API_KEY")
+	clientID := os.Getenv("SH_CLIENT_ID")
+	if apiKey == "" || clientID == "" {
+		return fmt.Errorf("SH_API_KEY and SH_CLIENT_ID required")
+	}
+	c, err := api.New(apiKey, clientID)
+	if err != nil {
+		return fmt.Errorf("api.New: %w", err)
+	}
+
+	resp, err := redirect.New(c).ListRedirects(context.Background(),
+		redirect.ListRedirectsRequest{PageSize: 100})
+	if err != nil {
+		return fmt.Errorf("ListRedirects: %w", err)
+	}
+
+	total := 0
+	for _, rules := range resp.Return {
+		total += len(rules)
+	}
+	log.Printf("✓ %d domain(s), %d total redirect rule(s)", len(resp.Return), total)
+	for domain, rules := range resp.Return {
+		log.Printf("  %s", domain)
+		for source, rule := range rules {
+			log.Printf("    %d  %s -> %s", rule.Type, source, rule.Destination)
+		}
+	}
+	return nil
+}

--- a/pkg/api/redirect/doc.go
+++ b/pkg/api/redirect/doc.go
@@ -1,0 +1,4 @@
+// Package redirect wraps the /redirect API endpoint — currently
+// just /redirect/list_redirects.json, the per-account inventory of
+// HTTP redirect rules grouped by domain.
+package redirect

--- a/pkg/api/redirect/listredirects.go
+++ b/pkg/api/redirect/listredirects.go
@@ -1,0 +1,46 @@
+package redirect
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// ListRedirects returns every redirect rule on the account via
+// /redirect/list_redirects.json, grouped by domain → source URL →
+// (destination + HTTP type).
+//
+// Pagination filters control the result window if the account has
+// a lot of rules.
+func (s *Client) ListRedirects(ctx context.Context, request ListRedirectsRequest) (response ListRedirectsResponse, err error) {
+	keys := []string{"apikey", "client_id"}
+
+	req, err := s.client.NewRequest("GET", "redirect/list_redirects.json", "")
+	if err != nil {
+		return response, err
+	}
+	v := req.URL.Query()
+	if request.SortBy != "" {
+		v.Add("filters[sort_by]", request.SortBy)
+		keys = append(keys, "filters[sort_by]")
+	}
+	if request.SortDir != "" {
+		v.Add("filters[sort_dir]", request.SortDir)
+		keys = append(keys, "filters[sort_dir]")
+	}
+	if request.PageSize != 0 {
+		v.Add("filters[page_size]", strconv.Itoa(request.PageSize))
+		keys = append(keys, "filters[page_size]")
+	}
+	if request.PageNumber != 0 {
+		v.Add("filters[page_number]", strconv.Itoa(request.PageNumber))
+		keys = append(keys, "filters[page_number]")
+	}
+	req.URL.RawQuery = net.Encode(v, keys)
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/redirect/listredirects_test.go
+++ b/pkg/api/redirect/listredirects_test.go
@@ -45,6 +45,29 @@ func TestListRedirects_ParsesNestedShape(t *testing.T) {
 	}
 }
 
+func TestListRedirects_EmptyArrayShape(t *testing.T) {
+	// The live API returns the JSON array [] (not the empty object
+	// {}) when an account has no redirects. Custom UnmarshalJSON
+	// must tolerate this.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"return":[],"msg":"Successful","status":true}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).ListRedirects(context.Background(), ListRedirectsRequest{})
+	if err != nil {
+		t.Fatalf("ListRedirects: %v", err)
+	}
+	if got.Return == nil {
+		t.Errorf("Return should be non-nil even for empty result")
+	}
+	if len(got.Return) != 0 {
+		t.Errorf("Return = %+v, want empty map", got.Return)
+	}
+}
+
 func TestListRedirects_PagingFilters(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()

--- a/pkg/api/redirect/listredirects_test.go
+++ b/pkg/api/redirect/listredirects_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestListRedirects_ParsesNestedShape(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/redirect/list_redirects.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -46,10 +47,11 @@ func TestListRedirects_ParsesNestedShape(t *testing.T) {
 }
 
 func TestListRedirects_EmptyArrayShape(t *testing.T) {
+	t.Parallel()
 	// The live API returns the JSON array [] (not the empty object
 	// {}) when an account has no redirects. Custom UnmarshalJSON
 	// must tolerate this.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"return":[],"msg":"Successful","status":true}`)
 	}))
@@ -69,6 +71,7 @@ func TestListRedirects_EmptyArrayShape(t *testing.T) {
 }
 
 func TestListRedirects_PagingFilters(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		if q.Get("filters[page_size]") != "50" || q.Get("filters[page_number]") != "3" {

--- a/pkg/api/redirect/listredirects_test.go
+++ b/pkg/api/redirect/listredirects_test.go
@@ -1,0 +1,68 @@
+package redirect
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestListRedirects_ParsesNestedShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/redirect/list_redirects.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true, "msg": "Successful",
+			"return": {
+				"example.kiwi.nz": {
+					"a.example.kiwi.nz": {"destination": "https://movedpermanently.com", "type": 301},
+					"b.example.kiwi.nz/blog/category": {"destination": "https://movedtemporarily.com", "type": 302}
+				}
+			}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).ListRedirects(context.Background(), ListRedirectsRequest{})
+	if err != nil {
+		t.Fatalf("ListRedirects: %v", err)
+	}
+	rules := got.Return["example.kiwi.nz"]
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules under example.kiwi.nz, got %d", len(rules))
+	}
+	if rules["a.example.kiwi.nz"].Type != 301 {
+		t.Errorf("a.example.kiwi.nz type = %d", rules["a.example.kiwi.nz"].Type)
+	}
+	if rules["b.example.kiwi.nz/blog/category"].Destination != "https://movedtemporarily.com" {
+		t.Errorf("destination = %q", rules["b.example.kiwi.nz/blog/category"].Destination)
+	}
+}
+
+func TestListRedirects_PagingFilters(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("filters[page_size]") != "50" || q.Get("filters[page_number]") != "3" {
+			t.Errorf("paging = %v", q)
+		}
+		if q.Get("filters[sort_by]") != "domain" || q.Get("filters[sort_dir]") != "ASC" {
+			t.Errorf("sort = %v", q)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{}}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).ListRedirects(context.Background(), ListRedirectsRequest{
+		SortBy: "domain", SortDir: "ASC", PageSize: 50, PageNumber: 3,
+	}); err != nil {
+		t.Fatalf("ListRedirects: %v", err)
+	}
+}

--- a/pkg/api/redirect/models.go
+++ b/pkg/api/redirect/models.go
@@ -1,0 +1,20 @@
+package redirect
+
+import "github.com/sitehostnz/gosh/pkg/api"
+
+// Client wraps the api.Client for the /redirect endpoints.
+type Client struct {
+	client *api.Client
+}
+
+// New initialises a redirect Client.
+func New(c *api.Client) *Client {
+	return &Client{client: c}
+}
+
+// Rule describes one redirect: where the source URL points to and
+// the HTTP status code (typically 301 or 302).
+type Rule struct {
+	Destination string `json:"destination"`
+	Type        int    `json:"type"`
+}

--- a/pkg/api/redirect/request.go
+++ b/pkg/api/redirect/request.go
@@ -1,0 +1,10 @@
+package redirect
+
+// ListRedirectsRequest paginates / sorts the redirect listing. All
+// fields are optional.
+type ListRedirectsRequest struct {
+	SortBy     string
+	SortDir    string
+	PageSize   int
+	PageNumber int
+}

--- a/pkg/api/redirect/response.go
+++ b/pkg/api/redirect/response.go
@@ -1,0 +1,24 @@
+package redirect
+
+import "github.com/sitehostnz/gosh/pkg/models"
+
+// ListRedirectsResponse is the return from /redirect/list_redirects.json.
+//
+// The API returns a nested map: the outer key is the domain, the
+// inner key is the source URL (host + optional path), and the value
+// is the Rule (destination + status code).
+//
+//	{
+//	  "example.kiwi.nz": {
+//	    "a.example.kiwi.nz": {"destination": "https://...", "type": 301},
+//	    "b.example.kiwi.nz/blog": {"destination": "https://...", "type": 302}
+//	  }
+//	}
+//
+// Modelled as map[domain]map[sourceURL]Rule rather than a flat list
+// to match the wire shape; consumers wanting a flat slice can range
+// over both levels themselves.
+type ListRedirectsResponse struct {
+	Return map[string]map[string]Rule `json:"return"`
+	models.APIResponse
+}

--- a/pkg/api/redirect/response.go
+++ b/pkg/api/redirect/response.go
@@ -1,12 +1,16 @@
 package redirect
 
-import "github.com/sitehostnz/gosh/pkg/models"
+import (
+	"encoding/json"
+
+	"github.com/sitehostnz/gosh/pkg/models"
+)
 
 // ListRedirectsResponse is the return from /redirect/list_redirects.json.
 //
-// The API returns a nested map: the outer key is the domain, the
-// inner key is the source URL (host + optional path), and the value
-// is the Rule (destination + status code).
+// **Wire-shape quirk** (verified live, May 2026): when the account
+// has redirects, "return" is a nested map keyed by domain → source
+// URL → Rule:
 //
 //	{
 //	  "example.kiwi.nz": {
@@ -15,10 +19,34 @@ import "github.com/sitehostnz/gosh/pkg/models"
 //	  }
 //	}
 //
-// Modelled as map[domain]map[sourceURL]Rule rather than a flat list
-// to match the wire shape; consumers wanting a flat slice can range
-// over both levels themselves.
+// When the account has **zero** redirects, "return" is the JSON
+// array `[]`, not the empty object `{}`. The docs only show the
+// populated form, so consumers parsing the obvious map shape would
+// fail on empty accounts.
+//
+// Custom UnmarshalJSON handles both: the empty array is decoded as
+// an empty map; the populated map is decoded normally.
 type ListRedirectsResponse struct {
 	Return map[string]map[string]Rule `json:"return"`
 	models.APIResponse
+}
+
+// UnmarshalJSON tolerates the empty-array form the API returns
+// when the account has no redirect rules. See type comment.
+func (r *ListRedirectsResponse) UnmarshalJSON(data []byte) error {
+	var envelope struct {
+		Return json.RawMessage `json:"return"`
+		models.APIResponse
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return err
+	}
+	r.APIResponse = envelope.APIResponse
+
+	raw := envelope.Return
+	if len(raw) == 0 || string(raw) == "null" || string(raw) == "[]" {
+		r.Return = map[string]map[string]Rule{}
+		return nil
+	}
+	return json.Unmarshal(raw, &r.Return)
 }


### PR DESCRIPTION
## Summary

Adds a new top-level \`pkg/api/redirect\` package wrapping
\`redirect/list_redirects.json\`.

Includes a custom \`UnmarshalJSON\` that tolerates the API's
empty-result quirk: when no redirects exist, the API returns
\`return: []\` rather than \`return: {}\` — a different JSON shape from
the populated case. The wrapper handles both.

## Test plan

- [x] unit tests for empty + populated responses
- [x] live-validated against accounts with and without redirects