### PR TITLE
misc: small filler set across existing packages

### DIFF
--- a/pkg/api/cloud/stack/environment/delete.go
+++ b/pkg/api/cloud/stack/environment/delete.go
@@ -1,0 +1,48 @@
+package environment
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Delete removes the named environment variables from a stack
+// service via "cloud/stack/environment/delete.json". The variables
+// to remove are passed by name; their values aren't required.
+//
+// Same param shape as Update — server, project, service — with
+// `variables[N][name]` instead of `variables[N][name]` +
+// `variables[N][content]` pairs.
+func (s *Client) Delete(ctx context.Context, request DeleteRequest) (response DeleteResponse, err error) {
+	uri := "cloud/stack/environment/delete.json"
+	keys := []string{
+		"client_id",
+		"server",
+		"project",
+		"service",
+	}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server", request.ServerName)
+	values.Add("project", request.Project)
+	values.Add("service", request.Service)
+
+	args := make([]string, len(request.Names))
+	for i, name := range request.Names {
+		k := fmt.Sprintf("variables[%d][name]", i)
+		args[i] = k
+		values.Add(k, name)
+	}
+
+	req, err := s.client.NewRequest("POST", uri, net.Encode(values, append(keys, args...)))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/stack/environment/delete.go
+++ b/pkg/api/cloud/stack/environment/delete.go
@@ -15,6 +15,9 @@ import (
 // Same param shape as Update — server, project, service — with
 // `variables[N][name]` instead of `variables[N][name]` +
 // `variables[N][content]` pairs.
+//
+// Async: the response carries a scheduler job descriptor; poll via
+// job.Get to confirm the variables were actually removed.
 func (s *Client) Delete(ctx context.Context, request DeleteRequest) (response DeleteResponse, err error) {
 	uri := "cloud/stack/environment/delete.json"
 	keys := []string{

--- a/pkg/api/cloud/stack/environment/delete_test.go
+++ b/pkg/api/cloud/stack/environment/delete_test.go
@@ -32,7 +32,7 @@ func TestDelete_Success(t *testing.T) {
 			t.Errorf("variables = %v", v)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":"123","type":"scheduler"}}}`)
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":123,"type":"scheduler"}}}`)
 	}))
 	defer srv.Close()
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
@@ -43,8 +43,8 @@ func TestDelete_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
-	if got.Return.ID != "123" {
-		t.Errorf("Return.Job.ID = %q, want \"123\"", got.Return.ID)
+	if got.Return.ID != 123 {
+		t.Errorf("Return.Job.ID = %d, want 123", got.Return.ID)
 	}
 	if got.Return.Type != "scheduler" {
 		t.Errorf("Return.Job.Type = %q, want \"scheduler\"", got.Return.Type)

--- a/pkg/api/cloud/stack/environment/delete_test.go
+++ b/pkg/api/cloud/stack/environment/delete_test.go
@@ -32,14 +32,21 @@ func TestDelete_Success(t *testing.T) {
 			t.Errorf("variables = %v", v)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful"}`)
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":"123","type":"scheduler"}}}`)
 	}))
 	defer srv.Close()
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
-	if _, err := New(c).Delete(context.Background(), DeleteRequest{
+	got, err := New(c).Delete(context.Background(), DeleteRequest{
 		ServerName: "ch-test", Project: "myproj", Service: "web",
 		Names: []string{"FOO", "BAR"},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("Delete: %v", err)
+	}
+	if got.Return.ID != "123" {
+		t.Errorf("Return.Job.ID = %q, want \"123\"", got.Return.ID)
+	}
+	if got.Return.Type != "scheduler" {
+		t.Errorf("Return.Job.Type = %q, want \"scheduler\"", got.Return.Type)
 	}
 }

--- a/pkg/api/cloud/stack/environment/delete_test.go
+++ b/pkg/api/cloud/stack/environment/delete_test.go
@@ -1,0 +1,44 @@
+package environment
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestDelete_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/stack/environment/delete.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		v, _ := url.ParseQuery(string(body))
+		if v.Get("server") != "ch-test" {
+			t.Errorf("server = %q (note: not 'server_name')", v.Get("server"))
+		}
+		if v.Get("project") != "myproj" {
+			t.Errorf("project = %q", v.Get("project"))
+		}
+		if v.Get("service") != "web" {
+			t.Errorf("service = %q", v.Get("service"))
+		}
+		if v.Get("variables[0][name]") != "FOO" || v.Get("variables[1][name]") != "BAR" {
+			t.Errorf("variables = %v", v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful"}`)
+	}))
+	defer srv.Close()
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).Delete(context.Background(), DeleteRequest{
+		ServerName: "ch-test", Project: "myproj", Service: "web",
+		Names: []string{"FOO", "BAR"},
+	}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}

--- a/pkg/api/cloud/stack/environment/delete_test.go
+++ b/pkg/api/cloud/stack/environment/delete_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestDelete_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/stack/environment/delete.json" {
 			t.Errorf("path = %q", r.URL.Path)

--- a/pkg/api/cloud/stack/environment/request.go
+++ b/pkg/api/cloud/stack/environment/request.go
@@ -17,4 +17,14 @@ type (
 		Service              string `json:"service"`
 		EnvironmentVariables []models.EnvironmentVariable
 	}
+
+	// DeleteRequest removes the named environment variables from a
+	// stack service. Names lists the variable names to drop; their
+	// values aren't required (and aren't sent on the wire).
+	DeleteRequest struct {
+		ServerName string   `json:"server"`
+		Project    string   `json:"project"`
+		Service    string   `json:"service"`
+		Names      []string `json:"-"`
+	}
 )

--- a/pkg/api/cloud/stack/environment/response.go
+++ b/pkg/api/cloud/stack/environment/response.go
@@ -16,4 +16,9 @@ type (
 		} `json:"return"`
 		models.APIResponse
 	}
+
+	// DeleteResponse is returned by environment/delete; synchronous.
+	DeleteResponse struct {
+		models.APIResponse
+	}
 )

--- a/pkg/api/cloud/stack/environment/response.go
+++ b/pkg/api/cloud/stack/environment/response.go
@@ -17,8 +17,14 @@ type (
 		models.APIResponse
 	}
 
-	// DeleteResponse is returned by environment/delete; synchronous.
+	// DeleteResponse is returned by environment/delete. Delete is
+	// async: the API queues a job and the response carries its
+	// descriptor. Poll via job.Get to confirm the variables were
+	// actually removed.
 	DeleteResponse struct {
+		Return struct {
+			models.Job `json:"job"`
+		} `json:"return"`
 		models.APIResponse
 	}
 )


### PR DESCRIPTION
## Summary

Small additive fixes across existing packages — missing fields on
response structs, doc-comment improvements, a couple of helper
functions where the existing surface required excessive boilerplate.

Each change is self-contained and additive; no breaking changes to
existing exported API.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` clean
- [x] live-validated against the relevant endpoints