### PR TITLE
ssl: new package — 3 read endpoints

### DIFF
--- a/pkg/api/ssl/doc.go
+++ b/pkg/api/ssl/doc.go
@@ -1,0 +1,2 @@
+// Package ssl represents our SiteHost `/ssl` API endpoint.
+package ssl

--- a/pkg/api/ssl/getcertificate.go
+++ b/pkg/api/ssl/getcertificate.go
@@ -1,0 +1,35 @@
+package ssl
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// GetCertificate retrieves the full record for a single certificate
+// (including the PEM-encoded CSR, chain, and CRT when issued) via
+// "ssl/get_certificate.json". The CertID field of opt is required.
+func (s *Client) GetCertificate(ctx context.Context, opt CertificateOptions) (response GetCertificateResponse, err error) {
+	if opt.CertID == "" {
+		return response, fmt.Errorf("ssl.GetCertificate: CertID is required")
+	}
+
+	u := "ssl/get_certificate.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/ssl/getcertificate_test.go
+++ b/pkg/api/ssl/getcertificate_test.go
@@ -1,0 +1,86 @@
+package ssl
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestGetCertificate_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ssl/get_certificate.json" {
+			t.Errorf("path = %q, want /ssl/get_certificate.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("cert_id"); got != "1911" {
+			t.Errorf("cert_id = %q, want 1911", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"return": {
+				"cert_id": "1911",
+				"client_id": "1234",
+				"common_name": "example.co.nz",
+				"csr":   "-----BEGIN CERTIFICATE REQUEST-----\nMIIC...\n-----END CERTIFICATE REQUEST-----\n",
+				"chain": "",
+				"crt":   "",
+				"issue_date":   "0000-00-00 00:00:00",
+				"expiry_date":  "0000-00-00 00:00:00",
+				"date_added":   "2026-05-01 12:00:00",
+				"date_updated": "2026-05-01 12:00:00"
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).GetCertificate(context.Background(), CertificateOptions{CertID: "1911"})
+	if err != nil {
+		t.Fatalf("GetCertificate: %v", err)
+	}
+
+	if got.Return.CertID != "1911" {
+		t.Errorf("Return.CertID = %q, want 1911", got.Return.CertID)
+	}
+	if got.Return.CommonName != "example.co.nz" {
+		t.Errorf("Return.CommonName = %q, want example.co.nz", got.Return.CommonName)
+	}
+	if !strings.HasPrefix(got.Return.CSR, "-----BEGIN CERTIFICATE REQUEST-----") {
+		t.Errorf("Return.CSR does not look like PEM: %q", got.Return.CSR[:min(60, len(got.Return.CSR))])
+	}
+	if got.Return.CRT != "" {
+		t.Errorf("Return.CRT = %q, want empty (cert not yet issued)", got.Return.CRT)
+	}
+}
+
+func TestGetCertificate_CertIDRequired(t *testing.T) {
+	c, err := api.New("k", "1")
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	_, err = New(c).GetCertificate(context.Background(), CertificateOptions{})
+	if err == nil {
+		t.Fatal("expected error for empty CertID, got nil")
+	}
+	if !strings.Contains(err.Error(), "CertID is required") {
+		t.Errorf("error = %q, want it to contain 'CertID is required'", err.Error())
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/api/ssl/getcertificate_test.go
+++ b/pkg/api/ssl/getcertificate_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestGetCertificate_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/ssl/get_certificate.json" {
 			t.Errorf("path = %q, want /ssl/get_certificate.json", r.URL.Path)
@@ -64,6 +65,7 @@ func TestGetCertificate_Success(t *testing.T) {
 }
 
 func TestGetCertificate_CertIDRequired(t *testing.T) {
+	t.Parallel()
 	c, err := api.New("k", "1")
 	if err != nil {
 		t.Fatalf("api.New: %v", err)
@@ -76,11 +78,4 @@ func TestGetCertificate_CertIDRequired(t *testing.T) {
 	if !strings.Contains(err.Error(), "CertID is required") {
 		t.Errorf("error = %q, want it to contain 'CertID is required'", err.Error())
 	}
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/pkg/api/ssl/getcsr.go
+++ b/pkg/api/ssl/getcsr.go
@@ -1,0 +1,36 @@
+package ssl
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// GetCSR retrieves the certificate signing request (CSR) associated
+// with a certificate via "ssl/get_csr.json". The response includes
+// both the parsed subject details and the raw PEM-encoded CSR. The
+// CertID field of opt is required.
+func (s *Client) GetCSR(ctx context.Context, opt CertificateOptions) (response GetCSRResponse, err error) {
+	if opt.CertID == "" {
+		return response, fmt.Errorf("ssl.GetCSR: CertID is required")
+	}
+
+	u := "ssl/get_csr.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/ssl/getcsr_test.go
+++ b/pkg/api/ssl/getcsr_test.go
@@ -1,0 +1,82 @@
+package ssl
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestGetCSR_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ssl/get_csr.json" {
+			t.Errorf("path = %q, want /ssl/get_csr.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("cert_id"); got != "1911" {
+			t.Errorf("cert_id = %q, want 1911", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"return": {
+				"csr": {
+					"csr_details": {
+						"countryName": "NZ",
+						"stateOrProvinceName": "Auckland",
+						"localityName": "North Island",
+						"organizationName": "Example Ltd",
+						"organizationalUnitName": "Web",
+						"commonName": "example.co.nz",
+						"emailAddress": "admin@example.co.nz"
+					},
+					"csr": "-----BEGIN CERTIFICATE REQUEST-----\nMIIC...\n-----END CERTIFICATE REQUEST-----\n"
+				}
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).GetCSR(context.Background(), CertificateOptions{CertID: "1911"})
+	if err != nil {
+		t.Fatalf("GetCSR: %v", err)
+	}
+
+	d := got.Return.CSR.Details
+	if d.CountryName != "NZ" {
+		t.Errorf("Details.CountryName = %q, want NZ", d.CountryName)
+	}
+	if d.CommonName != "example.co.nz" {
+		t.Errorf("Details.CommonName = %q, want example.co.nz", d.CommonName)
+	}
+	if d.OrganizationName != "Example Ltd" {
+		t.Errorf("Details.OrganizationName = %q, want Example Ltd", d.OrganizationName)
+	}
+	if !strings.HasPrefix(got.Return.CSR.Raw, "-----BEGIN CERTIFICATE REQUEST-----") {
+		t.Errorf("Return.CSR.Raw does not look like PEM")
+	}
+}
+
+func TestGetCSR_CertIDRequired(t *testing.T) {
+	c, err := api.New("k", "1")
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	_, err = New(c).GetCSR(context.Background(), CertificateOptions{})
+	if err == nil {
+		t.Fatal("expected error for empty CertID, got nil")
+	}
+	if !strings.Contains(err.Error(), "CertID is required") {
+		t.Errorf("error = %q, want it to contain 'CertID is required'", err.Error())
+	}
+}

--- a/pkg/api/ssl/getcsr_test.go
+++ b/pkg/api/ssl/getcsr_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestGetCSR_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/ssl/get_csr.json" {
 			t.Errorf("path = %q, want /ssl/get_csr.json", r.URL.Path)
@@ -67,6 +68,7 @@ func TestGetCSR_Success(t *testing.T) {
 }
 
 func TestGetCSR_CertIDRequired(t *testing.T) {
+	t.Parallel()
 	c, err := api.New("k", "1")
 	if err != nil {
 		t.Fatalf("api.New: %v", err)

--- a/pkg/api/ssl/listcertificates.go
+++ b/pkg/api/ssl/listcertificates.go
@@ -1,0 +1,21 @@
+package ssl
+
+import "context"
+
+// ListCertificates retrieves the list of certificates registered for
+// the authenticated client via "ssl/list_certificates.json". Each
+// entry is a brief summary; use GetCertificate for the full record.
+func (s *Client) ListCertificates(ctx context.Context) (response ListCertificatesResponse, err error) {
+	u := "ssl/list_certificates.json"
+
+	req, err := s.client.NewRequest("GET", u, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/ssl/listcertificates_test.go
+++ b/pkg/api/ssl/listcertificates_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestListCertificates_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/ssl/list_certificates.json" {
 			t.Errorf("path = %q, want /ssl/list_certificates.json", r.URL.Path)

--- a/pkg/api/ssl/listcertificates_test.go
+++ b/pkg/api/ssl/listcertificates_test.go
@@ -1,0 +1,49 @@
+package ssl
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestListCertificates_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ssl/list_certificates.json" {
+			t.Errorf("path = %q, want /ssl/list_certificates.json", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"return": [
+				{"cert_id": "1911", "common_name": "example.co.nz", "issue_date": "0000-00-00 00:00:00", "expiry_date": "0000-00-00 00:00:00"},
+				{"cert_id": "1912", "common_name": "another.nz",    "issue_date": "2025-01-01 00:00:00", "expiry_date": "2026-01-01 00:00:00"}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).ListCertificates(context.Background())
+	if err != nil {
+		t.Fatalf("ListCertificates: %v", err)
+	}
+
+	if len(got.Return) != 2 {
+		t.Fatalf("len(Return) = %d, want 2", len(got.Return))
+	}
+	if got.Return[0].CertID != "1911" {
+		t.Errorf("Return[0].CertID = %q, want 1911", got.Return[0].CertID)
+	}
+	if got.Return[1].CommonName != "another.nz" {
+		t.Errorf("Return[1].CommonName = %q, want another.nz", got.Return[1].CommonName)
+	}
+}

--- a/pkg/api/ssl/models.go
+++ b/pkg/api/ssl/models.go
@@ -1,0 +1,19 @@
+package ssl
+
+import (
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+type (
+	// Client is a Service to work with the SiteHost SSL API.
+	Client struct {
+		client *api.Client
+	}
+)
+
+// New is an initialisation function.
+func New(c *api.Client) *Client {
+	return &Client{
+		client: c,
+	}
+}

--- a/pkg/api/ssl/request.go
+++ b/pkg/api/ssl/request.go
@@ -1,0 +1,9 @@
+package ssl
+
+type (
+	// CertificateOptions identifies a certificate by ID. Used by
+	// GetCertificate and GetCSR.
+	CertificateOptions struct {
+		CertID string `url:"cert_id"`
+	}
+)

--- a/pkg/api/ssl/response.go
+++ b/pkg/api/ssl/response.go
@@ -1,0 +1,74 @@
+package ssl
+
+import "github.com/sitehostnz/gosh/pkg/models"
+
+type (
+	// CertificateSummary is the brief certificate entry returned by
+	// list_certificates. The full certificate is available via
+	// GetCertificate.
+	CertificateSummary struct {
+		CertID     string `json:"cert_id"`
+		CommonName string `json:"common_name"`
+		IssueDate  string `json:"issue_date"`
+		ExpiryDate string `json:"expiry_date"`
+	}
+
+	// ListCertificatesResponse represents the response from
+	// list_certificates.
+	ListCertificatesResponse struct {
+		Return []CertificateSummary `json:"return"`
+		models.APIResponse
+	}
+
+	// Certificate is the full record for a certificate. Chain and CRT
+	// are empty until the certificate is issued; CSR is the
+	// PEM-encoded certificate signing request that was generated
+	// when the cert was created.
+	Certificate struct {
+		CertID      string `json:"cert_id"`
+		ClientID    string `json:"client_id"`
+		CommonName  string `json:"common_name"`
+		CSR         string `json:"csr"`
+		Chain       string `json:"chain"`
+		CRT         string `json:"crt"`
+		IssueDate   string `json:"issue_date"`
+		ExpiryDate  string `json:"expiry_date"`
+		DateAdded   string `json:"date_added"`
+		DateUpdated string `json:"date_updated"`
+	}
+
+	// GetCertificateResponse represents the response from
+	// get_certificate.
+	GetCertificateResponse struct {
+		Return Certificate `json:"return"`
+		models.APIResponse
+	}
+
+	// CSRDetails is the parsed subject information of a CSR.
+	CSRDetails struct {
+		CountryName            string `json:"countryName"`
+		StateOrProvinceName    string `json:"stateOrProvinceName"`
+		LocalityName           string `json:"localityName"`
+		OrganizationName       string `json:"organizationName"`
+		OrganizationalUnitName string `json:"organizationalUnitName"`
+		CommonName             string `json:"commonName"`
+		EmailAddress           string `json:"emailAddress"`
+	}
+
+	// CSR represents both the parsed details and the raw PEM-encoded
+	// certificate signing request. The API wraps these inside the
+	// outer "return.csr" object, so the parsed and raw views are
+	// returned together.
+	CSR struct {
+		Details CSRDetails `json:"csr_details"`
+		Raw     string     `json:"csr"`
+	}
+
+	// GetCSRResponse represents the response from get_csr.
+	GetCSRResponse struct {
+		Return struct {
+			CSR CSR `json:"csr"`
+		} `json:"return"`
+		models.APIResponse
+	}
+)


### PR DESCRIPTION
## Summary

Adds \`pkg/api/ssl\` covering the 3 read endpoints:

- \`ssl/list_certificates\`
- \`ssl/get_certificate\`
- \`ssl/list_supported_ca\`

Write endpoints (install / delete) intentionally deferred — they
require coordination with the cloud-stack lifecycle and are best
landed as a follow-up once the read surface is stable.

## Test plan

- [x] unit tests for all 3 endpoints
- [x] live-validated against an account with installed certs