### PR TITLE
mail: full surface — domains / aliases / accounts / forwards / list_all union view

### DIFF
--- a/examples/mail-list-all/main.go
+++ b/examples/mail-list-all/main.go
@@ -1,0 +1,88 @@
+// Program mail-list-all is a read-only validation of mail.ListAll
+// against a real mail server. Lists every domain on the server,
+// then for the first domain calls ListAll and breaks the records
+// out by Type (mailbox / alias / forward).
+//
+// Required env: SH_API_KEY, SH_CLIENT_ID, SH_MAIL_SERVER.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+	"github.com/sitehostnz/gosh/pkg/api/mail"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("mail-list-all: %v", err)
+	}
+}
+
+func run() error {
+	apiKey := os.Getenv("SH_API_KEY")
+	clientID := os.Getenv("SH_CLIENT_ID")
+	mailServer := os.Getenv("SH_MAIL_SERVER")
+	if apiKey == "" || clientID == "" || mailServer == "" {
+		return fmt.Errorf("SH_API_KEY, SH_CLIENT_ID, SH_MAIL_SERVER required")
+	}
+	c, err := api.New(apiKey, clientID)
+	if err != nil {
+		return fmt.Errorf("api.New: %w", err)
+	}
+
+	mc := mail.New(c)
+	ctx := context.Background()
+
+	// 1. Discover the domains on the server.
+	domains, err := mc.ListDomains(ctx, mail.ListDomainsOptions{
+		ServerOptions: mail.ServerOptions{ServerName: mailServer},
+	})
+	if err != nil {
+		return fmt.Errorf("ListDomains: %w", err)
+	}
+	log.Printf("✓ %s: %d domain(s)", mailServer, len(domains.Return))
+	if len(domains.Return) == 0 {
+		log.Printf("  no domains on this server — nothing to ListAll against")
+		return nil
+	}
+	for _, d := range domains.Return {
+		log.Printf("  %s  state=%s  accts=%d aliases=%d fwds=%d",
+			d.Domain, d.State, d.Accounts, d.Nicknames, d.Forwarders)
+	}
+
+	// 2. ListAll against the first domain.
+	target := domains.Return[0].Domain
+	log.Printf("==> ListAll(%s, %s)", mailServer, target)
+	all, err := mc.ListAll(ctx, mail.ListAllOptions{
+		ServerOptions: mail.ServerOptions{ServerName: mailServer},
+		Domain:        target,
+	})
+	if err != nil {
+		return fmt.Errorf("ListAll: %w", err)
+	}
+	log.Printf("✓ %d record(s) total", len(all.Return))
+	mailboxes, aliases, forwards := 0, 0, 0
+	for _, r := range all.Return {
+		switch r.Type {
+		case 0:
+			mailboxes++
+			log.Printf("  [mailbox] %s  username=%s  label=%q",
+				r.EmailAddr, r.Username, r.Label)
+		case 1:
+			aliases++
+			log.Printf("  [alias  ] %s  -> %s", r.EmailAddr, r.Destination)
+		case 2:
+			forwards++
+			log.Printf("  [forward] %s  -> %s", r.EmailAddr, r.Destination)
+		default:
+			log.Printf("  [type=%d ] %s  (unexpected type)", r.Type, r.EmailAddr)
+		}
+	}
+	log.Printf("==> breakdown: %d mailboxes, %d aliases, %d forwards",
+		mailboxes, aliases, forwards)
+	return nil
+}

--- a/examples/mail-list-all/main.go
+++ b/examples/mail-list-all/main.go
@@ -65,8 +65,14 @@ func run() error {
 		return fmt.Errorf("ListAll: %w", err)
 	}
 	log.Printf("✓ %d record(s) total", len(all.Return))
-	mailboxes, aliases, forwards := 0, 0, 0
-	for _, r := range all.Return {
+	mailboxes, aliases, forwards := categorise(all.Return)
+	log.Printf("==> breakdown: %d mailboxes, %d aliases, %d forwards",
+		mailboxes, aliases, forwards)
+	return nil
+}
+
+func categorise(records []mail.EmailRecord) (mailboxes, aliases, forwards int) {
+	for _, r := range records {
 		switch r.Type {
 		case 0:
 			mailboxes++
@@ -82,7 +88,5 @@ func run() error {
 			log.Printf("  [type=%d ] %s  (unexpected type)", r.Type, r.EmailAddr)
 		}
 	}
-	log.Printf("==> breakdown: %d mailboxes, %d aliases, %d forwards",
-		mailboxes, aliases, forwards)
-	return nil
+	return mailboxes, aliases, forwards
 }

--- a/pkg/api/mail/addaccount.go
+++ b/pkg/api/mail/addaccount.go
@@ -1,0 +1,39 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+)
+
+// AddAccount creates a new mail account on the specified server
+// via "mail/add_account.json". ServerName, Email, and
+// Params.Password are required. Returns a JobResponse with the
+// scheduler job ID.
+func (s *Client) AddAccount(ctx context.Context, opt AddAccountOptions) (response JobResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.AddAccount: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Email == "" {
+		return response, fmt.Errorf("mail.AddAccount: Email is required")
+	}
+	if opt.Password == "" {
+		return response, fmt.Errorf("mail.AddAccount: Password is required")
+	}
+	opt.ServerName = server
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "mail/add_account.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/mail/addalias.go
+++ b/pkg/api/mail/addalias.go
@@ -1,0 +1,38 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+)
+
+// AddAlias adds an alias mapping (Source → Destination) via
+// "mail/add_alias.json". ServerName, Source, and Destination
+// are required. Returns a JobResponse.
+func (s *Client) AddAlias(ctx context.Context, opt AddAliasOptions) (response JobResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.AddAlias: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Source == "" {
+		return response, fmt.Errorf("mail.AddAlias: Source is required")
+	}
+	if opt.Destination == "" {
+		return response, fmt.Errorf("mail.AddAlias: Destination is required")
+	}
+	opt.ServerName = server
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "mail/add_alias.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/mail/addaliasdomain.go
+++ b/pkg/api/mail/addaliasdomain.go
@@ -1,0 +1,41 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// AddAliasDomain adds an alias-domain mapping (one domain
+// pointing at another for mail purposes) via
+// "mail/add_alias_domain.json". ServerName, AliasDomain, and
+// ParentDomain are required. Synchronous; returns
+// models.APIResponse only.
+func (s *Client) AddAliasDomain(ctx context.Context, opt AddAliasDomainOptions) (response models.APIResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.AddAliasDomain: ServerName is required (or set via NewForServer)")
+	}
+	if opt.AliasDomain == "" {
+		return response, fmt.Errorf("mail.AddAliasDomain: AliasDomain is required")
+	}
+	if opt.ParentDomain == "" {
+		return response, fmt.Errorf("mail.AddAliasDomain: ParentDomain is required")
+	}
+	opt.ServerName = server
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "mail/add_alias_domain.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/mail/adddomain.go
+++ b/pkg/api/mail/adddomain.go
@@ -1,0 +1,40 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// AddDomain adds a domain to the specified mail server via
+// "mail/add_domain.json". ServerName and Domain are required.
+// Synchronous; returns models.APIResponse only.
+//
+// Note: per the SiteHost docs, the domain must already be
+// managed by the SiteHost Control Panel (i.e. exist as a DNS
+// zone) before it can be added as a mail domain.
+func (s *Client) AddDomain(ctx context.Context, opt AddDomainOptions) (response models.APIResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.AddDomain: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Domain == "" {
+		return response, fmt.Errorf("mail.AddDomain: Domain is required")
+	}
+	opt.ServerName = server
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "mail/add_domain.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/mail/addforward.go
+++ b/pkg/api/mail/addforward.go
@@ -1,0 +1,38 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+)
+
+// AddForward adds a forwarder mapping (Source → Destination)
+// via "mail/add_forward.json". ServerName, Source, and
+// Destination are required. Returns a JobResponse.
+func (s *Client) AddForward(ctx context.Context, opt AddForwardOptions) (response JobResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.AddForward: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Source == "" {
+		return response, fmt.Errorf("mail.AddForward: Source is required")
+	}
+	if opt.Destination == "" {
+		return response, fmt.Errorf("mail.AddForward: Destination is required")
+	}
+	opt.ServerName = server
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "mail/add_forward.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/mail/deleteaccount.go
+++ b/pkg/api/mail/deleteaccount.go
@@ -1,0 +1,35 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+)
+
+// DeleteAccount removes a mail account via
+// "mail/delete_account.json". ServerName and Email are required.
+// Returns a JobResponse.
+func (s *Client) DeleteAccount(ctx context.Context, opt DeleteAccountOptions) (response JobResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.DeleteAccount: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Email == "" {
+		return response, fmt.Errorf("mail.DeleteAccount: Email is required")
+	}
+	opt.ServerName = server
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "mail/delete_account.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/mail/deletealias.go
+++ b/pkg/api/mail/deletealias.go
@@ -1,0 +1,40 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// DeleteAlias removes an alias mapping via
+// "mail/delete_alias.json". ServerName, Source, and Destination
+// are all required — the API rejects calls with only Source.
+// Synchronous; returns models.APIResponse only.
+func (s *Client) DeleteAlias(ctx context.Context, opt DeleteAliasOptions) (response models.APIResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.DeleteAlias: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Source == "" {
+		return response, fmt.Errorf("mail.DeleteAlias: Source is required")
+	}
+	if opt.Destination == "" {
+		return response, fmt.Errorf("mail.DeleteAlias: Destination is required")
+	}
+	opt.ServerName = server
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "mail/delete_alias.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/mail/deletealiasdomain.go
+++ b/pkg/api/mail/deletealiasdomain.go
@@ -1,0 +1,36 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// DeleteAliasDomain removes an alias-domain mapping via
+// "mail/delete_alias_domain.json". ServerName and AliasDomain
+// are required. Synchronous; returns models.APIResponse only.
+func (s *Client) DeleteAliasDomain(ctx context.Context, opt DeleteAliasDomainOptions) (response models.APIResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.DeleteAliasDomain: ServerName is required (or set via NewForServer)")
+	}
+	if opt.AliasDomain == "" {
+		return response, fmt.Errorf("mail.DeleteAliasDomain: AliasDomain is required")
+	}
+	opt.ServerName = server
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "mail/delete_alias_domain.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/mail/deletedomain.go
+++ b/pkg/api/mail/deletedomain.go
@@ -1,0 +1,39 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// DeleteDomain removes a mail domain via
+// "mail/delete_domain.json". ServerName and Domain are required.
+// Synchronous; returns models.APIResponse only.
+//
+// The API refuses to delete a domain while aliases or forwards
+// still exist on it — clean those up first.
+func (s *Client) DeleteDomain(ctx context.Context, opt DeleteDomainOptions) (response models.APIResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.DeleteDomain: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Domain == "" {
+		return response, fmt.Errorf("mail.DeleteDomain: Domain is required")
+	}
+	opt.ServerName = server
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "mail/delete_domain.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/mail/deleteforward.go
+++ b/pkg/api/mail/deleteforward.go
@@ -1,0 +1,40 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// DeleteForward removes a forwarder mapping via
+// "mail/delete_forward.json". ServerName, Source, and
+// Destination are all required — the API rejects calls with
+// only Source. Synchronous; returns models.APIResponse only.
+func (s *Client) DeleteForward(ctx context.Context, opt DeleteForwardOptions) (response models.APIResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.DeleteForward: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Source == "" {
+		return response, fmt.Errorf("mail.DeleteForward: Source is required")
+	}
+	if opt.Destination == "" {
+		return response, fmt.Errorf("mail.DeleteForward: Destination is required")
+	}
+	opt.ServerName = server
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "mail/delete_forward.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/mail/doc.go
+++ b/pkg/api/mail/doc.go
@@ -1,0 +1,17 @@
+// Package mail represents our SiteHost `/mail` API endpoint —
+// shared mail service inspection (server info, domains, accounts,
+// aliases, forwarders).
+//
+// Every operation is scoped to a specific mail server (the
+// server_name parameter, e.g. "sth-mail-air" for the Shared Mail
+// Service). Consumers must specify which mail service to operate
+// against on every call. For ergonomics where a consumer only
+// uses one mail service, NewForServer captures the server_name
+// once; calls can omit it from per-request options or override
+// per call.
+//
+// Discoverability: at the time of writing, the SiteHost public
+// API does not expose an endpoint for client-side enumeration of
+// mapped mail services — consumers must obtain the server_name
+// out of band (e.g. from the operator).
+package mail

--- a/pkg/api/mail/getaccount.go
+++ b/pkg/api/mail/getaccount.go
@@ -1,0 +1,41 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// GetAccount returns the full record for a single mail account
+// (identified by email address) via "mail/get_account.json".
+// Both ServerName (or NewForServer default) and Email are
+// required.
+func (s *Client) GetAccount(ctx context.Context, opt GetAccountOptions) (response GetAccountResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.GetAccount: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Email == "" {
+		return response, fmt.Errorf("mail.GetAccount: Email is required")
+	}
+	opt.ServerName = server
+
+	u := "mail/get_account.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/mail/getaccount_test.go
+++ b/pkg/api/mail/getaccount_test.go
@@ -1,0 +1,85 @@
+package mail
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestGetAccount_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/get_account.json" {
+			t.Errorf("path = %q, want /mail/get_account.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("server_name"); got != "sth-mail-air" {
+			t.Errorf("server_name = %q, want sth-mail-air", got)
+		}
+		if got := r.URL.Query().Get("email"); got != "test@example.co.nz" {
+			t.Errorf("email = %q, want test@example.co.nz", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"return": {
+				"client_id": "1234",
+				"username": "test@example.co.nz",
+				"label": "Test Account",
+				"emailaddr": "test@example.co.nz",
+				"autoresponder": "0",
+				"autoresponder_text": "",
+				"spam_strategy": "0",
+				"active": "yes",
+				"quota": "0",
+				"quota_used": "0",
+				"quota_percent": "0",
+				"message_count": "0",
+				"last_updated": "0000-00-00 00:00:00",
+				"key": "",
+				"date_added": "2026-05-02 13:00:00"
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).GetAccount(context.Background(), GetAccountOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Email:         "test@example.co.nz",
+	})
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+
+	if got.Return.EmailAddr != "test@example.co.nz" {
+		t.Errorf("EmailAddr = %q, want test@example.co.nz", got.Return.EmailAddr)
+	}
+	if got.Return.Active != "yes" {
+		t.Errorf("Active = %q, want yes", got.Return.Active)
+	}
+	if got.Return.DateAdded != "2026-05-02 13:00:00" {
+		t.Errorf("DateAdded = %q, want 2026-05-02 13:00:00", got.Return.DateAdded)
+	}
+}
+
+func TestGetAccount_EmailRequired(t *testing.T) {
+	c, _ := api.New("k", "1")
+	_, err := New(c).GetAccount(context.Background(), GetAccountOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty Email, got nil")
+	}
+	if !strings.Contains(err.Error(), "Email is required") {
+		t.Errorf("error = %q, want it to contain 'Email is required'", err.Error())
+	}
+}

--- a/pkg/api/mail/getaccount_test.go
+++ b/pkg/api/mail/getaccount_test.go
@@ -11,13 +11,20 @@ import (
 	"github.com/sitehostnz/gosh/pkg/api"
 )
 
+const (
+	testServerName = "sth-mail-air"
+	testDomain     = "example.co.nz"
+	testEmail      = "alice@example.co.nz"
+)
+
 func TestGetAccount_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/get_account.json" {
 			t.Errorf("path = %q, want /mail/get_account.json", r.URL.Path)
 		}
-		if got := r.URL.Query().Get("server_name"); got != "sth-mail-air" {
-			t.Errorf("server_name = %q, want sth-mail-air", got)
+		if got := r.URL.Query().Get("server_name"); got != testServerName {
+			t.Errorf("server_name = %q, want %s", got, testServerName)
 		}
 		if got := r.URL.Query().Get("email"); got != "test@example.co.nz" {
 			t.Errorf("email = %q, want test@example.co.nz", got)
@@ -53,7 +60,7 @@ func TestGetAccount_Success(t *testing.T) {
 	}
 
 	got, err := New(c).GetAccount(context.Background(), GetAccountOptions{
-		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		ServerOptions: ServerOptions{ServerName: testServerName},
 		Email:         "test@example.co.nz",
 	})
 	if err != nil {
@@ -72,9 +79,10 @@ func TestGetAccount_Success(t *testing.T) {
 }
 
 func TestGetAccount_EmailRequired(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	_, err := New(c).GetAccount(context.Background(), GetAccountOptions{
-		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		ServerOptions: ServerOptions{ServerName: testServerName},
 	})
 	if err == nil {
 		t.Fatal("expected error for empty Email, got nil")

--- a/pkg/api/mail/getserverinfo.go
+++ b/pkg/api/mail/getserverinfo.go
@@ -1,0 +1,38 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// GetServerInfo returns connection details (hostname, webmail
+// URL, etc.) for the specified mail server via
+// "mail/get_server_info.json". ServerName is required, either
+// per-call in opt or via NewForServer.
+func (s *Client) GetServerInfo(ctx context.Context, opt GetServerInfoOptions) (response GetServerInfoResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.GetServerInfo: ServerName is required (or set via NewForServer)")
+	}
+	opt.ServerName = server
+
+	u := "mail/get_server_info.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/mail/getserverinfo_test.go
+++ b/pkg/api/mail/getserverinfo_test.go
@@ -1,0 +1,117 @@
+package mail
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestGetServerInfo_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/get_server_info.json" {
+			t.Errorf("path = %q, want /mail/get_server_info.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("server_name"); got != "sth-mail-air" {
+			t.Errorf("server_name = %q, want sth-mail-air", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"return": {
+				"hostname": "mx1.sitehost.co.nz",
+				"webmail_url": "https://webmail.sitehost.co.nz",
+				"date_added": "0000-00-00 00:00:00",
+				"date_updated": "2025-09-14 23:20:51"
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).GetServerInfo(context.Background(),
+		GetServerInfoOptions{ServerOptions: ServerOptions{ServerName: "sth-mail-air"}})
+	if err != nil {
+		t.Fatalf("GetServerInfo: %v", err)
+	}
+
+	if got.Return.Hostname != "mx1.sitehost.co.nz" {
+		t.Errorf("Hostname = %q, want mx1.sitehost.co.nz", got.Return.Hostname)
+	}
+	if got.Return.WebmailURL != "https://webmail.sitehost.co.nz" {
+		t.Errorf("WebmailURL = %q", got.Return.WebmailURL)
+	}
+}
+
+func TestGetServerInfo_ServerNameRequired(t *testing.T) {
+	c, err := api.New("k", "1")
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	_, err = New(c).GetServerInfo(context.Background(), GetServerInfoOptions{})
+	if err == nil {
+		t.Fatal("expected error for empty ServerName, got nil")
+	}
+	if !strings.Contains(err.Error(), "ServerName is required") {
+		t.Errorf("error = %q, want it to contain 'ServerName is required'", err.Error())
+	}
+}
+
+// TestGetServerInfo_DefaultServerNameInherited locks in the
+// NewForServer behaviour: a captured default is used when the
+// per-call options omit ServerName.
+func TestGetServerInfo_DefaultServerNameInherited(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("server_name"); got != "captured-default" {
+			t.Errorf("server_name = %q, want captured-default", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"hostname":"x","webmail_url":"y","date_added":"","date_updated":""}}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	// No ServerName in opt → falls back to captured default.
+	if _, err := NewForServer(c, "captured-default").GetServerInfo(
+		context.Background(), GetServerInfoOptions{}); err != nil {
+		t.Fatalf("GetServerInfo (default): %v", err)
+	}
+}
+
+// TestGetServerInfo_PerCallOverridesDefault locks in that an
+// explicit ServerName in the per-call options beats a captured
+// default.
+func TestGetServerInfo_PerCallOverridesDefault(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("server_name"); got != "per-call" {
+			t.Errorf("server_name = %q, want per-call (per-call must override default)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"hostname":"x","webmail_url":"y","date_added":"","date_updated":""}}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	if _, err := NewForServer(c, "captured-default").GetServerInfo(
+		context.Background(), GetServerInfoOptions{ServerOptions: ServerOptions{ServerName: "per-call"}}); err != nil {
+		t.Fatalf("GetServerInfo (override): %v", err)
+	}
+}

--- a/pkg/api/mail/getserverinfo_test.go
+++ b/pkg/api/mail/getserverinfo_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestGetServerInfo_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/get_server_info.json" {
 			t.Errorf("path = %q, want /mail/get_server_info.json", r.URL.Path)
@@ -53,6 +54,7 @@ func TestGetServerInfo_Success(t *testing.T) {
 }
 
 func TestGetServerInfo_ServerNameRequired(t *testing.T) {
+	t.Parallel()
 	c, err := api.New("k", "1")
 	if err != nil {
 		t.Fatalf("api.New: %v", err)
@@ -71,6 +73,7 @@ func TestGetServerInfo_ServerNameRequired(t *testing.T) {
 // NewForServer behaviour: a captured default is used when the
 // per-call options omit ServerName.
 func TestGetServerInfo_DefaultServerNameInherited(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Query().Get("server_name"); got != "captured-default" {
 			t.Errorf("server_name = %q, want captured-default", got)
@@ -96,6 +99,7 @@ func TestGetServerInfo_DefaultServerNameInherited(t *testing.T) {
 // explicit ServerName in the per-call options beats a captured
 // default.
 func TestGetServerInfo_PerCallOverridesDefault(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Query().Get("server_name"); got != "per-call" {
 			t.Errorf("server_name = %q, want per-call (per-call must override default)", got)

--- a/pkg/api/mail/listaccounts.go
+++ b/pkg/api/mail/listaccounts.go
@@ -1,0 +1,42 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// ListAccounts returns the mail accounts for a domain on the
+// specified mail server via "mail/list_accounts.json". Both
+// ServerName (or NewForServer default) and Domain are required;
+// EmailAddr is an optional filter restricting results to a
+// specific address.
+func (s *Client) ListAccounts(ctx context.Context, opt ListAccountsOptions) (response ListAccountsResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.ListAccounts: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Domain == "" {
+		return response, fmt.Errorf("mail.ListAccounts: Domain is required")
+	}
+	opt.ServerName = server
+
+	u := "mail/list_accounts.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/mail/listaccounts_test.go
+++ b/pkg/api/mail/listaccounts_test.go
@@ -1,0 +1,109 @@
+package mail
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestListAccounts_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/list_accounts.json" {
+			t.Errorf("path = %q, want /mail/list_accounts.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("server_name"); got != "sth-mail-air" {
+			t.Errorf("server_name = %q, want sth-mail-air", got)
+		}
+		if got := r.URL.Query().Get("domain"); got != "example.co.nz" {
+			t.Errorf("domain = %q, want example.co.nz", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"return": [
+				{
+					"client_id": "1234",
+					"username": "alice@example.co.nz",
+					"label": "Alice",
+					"emailaddr": "alice@example.co.nz",
+					"autoresponder": "0",
+					"autoresponder_text": "",
+					"spam_strategy": "0",
+					"active": "yes",
+					"quota": "0",
+					"quota_used": "1024",
+					"quota_percent": "5",
+					"message_count": "12",
+					"last_updated": "2026-05-01 09:00:00"
+				}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).ListAccounts(context.Background(), ListAccountsOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Domain:        "example.co.nz",
+	})
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+
+	if len(got.Return) != 1 {
+		t.Fatalf("len(Return) = %d, want 1", len(got.Return))
+	}
+	a := got.Return[0]
+	if a.EmailAddr != "alice@example.co.nz" {
+		t.Errorf("EmailAddr = %q, want alice@example.co.nz", a.EmailAddr)
+	}
+	if a.QuotaUsed != "1024" {
+		t.Errorf("QuotaUsed = %q, want 1024", a.QuotaUsed)
+	}
+	if a.MessageCount != "12" {
+		t.Errorf("MessageCount = %q, want 12", a.MessageCount)
+	}
+}
+
+func TestListAccounts_DomainRequired(t *testing.T) {
+	c, _ := api.New("k", "1")
+	_, err := New(c).ListAccounts(context.Background(), ListAccountsOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty Domain, got nil")
+	}
+	if !strings.Contains(err.Error(), "Domain is required") {
+		t.Errorf("error = %q, want it to contain 'Domain is required'", err.Error())
+	}
+}
+
+func TestListAccounts_EmailAddrFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("filters[emailaddr]"); got != "alice@example.co.nz" {
+			t.Errorf("filters[emailaddr] = %q, want alice@example.co.nz", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":[]}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	if _, err := New(c).ListAccounts(context.Background(), ListAccountsOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Domain:        "example.co.nz",
+		EmailAddr:     "alice@example.co.nz",
+	}); err != nil {
+		t.Fatalf("ListAccounts (filter): %v", err)
+	}
+}

--- a/pkg/api/mail/listaccounts_test.go
+++ b/pkg/api/mail/listaccounts_test.go
@@ -12,15 +12,16 @@ import (
 )
 
 func TestListAccounts_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/list_accounts.json" {
 			t.Errorf("path = %q, want /mail/list_accounts.json", r.URL.Path)
 		}
-		if got := r.URL.Query().Get("server_name"); got != "sth-mail-air" {
-			t.Errorf("server_name = %q, want sth-mail-air", got)
+		if got := r.URL.Query().Get("server_name"); got != testServerName {
+			t.Errorf("server_name = %q, want %s", got, testServerName)
 		}
-		if got := r.URL.Query().Get("domain"); got != "example.co.nz" {
-			t.Errorf("domain = %q, want example.co.nz", got)
+		if got := r.URL.Query().Get("domain"); got != testDomain {
+			t.Errorf("domain = %q, want %s", got, testDomain)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
@@ -53,8 +54,8 @@ func TestListAccounts_Success(t *testing.T) {
 	}
 
 	got, err := New(c).ListAccounts(context.Background(), ListAccountsOptions{
-		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
-		Domain:        "example.co.nz",
+		ServerOptions: ServerOptions{ServerName: testServerName},
+		Domain:        testDomain,
 	})
 	if err != nil {
 		t.Fatalf("ListAccounts: %v", err)
@@ -64,8 +65,8 @@ func TestListAccounts_Success(t *testing.T) {
 		t.Fatalf("len(Return) = %d, want 1", len(got.Return))
 	}
 	a := got.Return[0]
-	if a.EmailAddr != "alice@example.co.nz" {
-		t.Errorf("EmailAddr = %q, want alice@example.co.nz", a.EmailAddr)
+	if a.EmailAddr != testEmail {
+		t.Errorf("EmailAddr = %q, want %s", a.EmailAddr, testEmail)
 	}
 	if a.QuotaUsed != "1024" {
 		t.Errorf("QuotaUsed = %q, want 1024", a.QuotaUsed)
@@ -76,9 +77,10 @@ func TestListAccounts_Success(t *testing.T) {
 }
 
 func TestListAccounts_DomainRequired(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	_, err := New(c).ListAccounts(context.Background(), ListAccountsOptions{
-		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		ServerOptions: ServerOptions{ServerName: testServerName},
 	})
 	if err == nil {
 		t.Fatal("expected error for empty Domain, got nil")
@@ -89,9 +91,10 @@ func TestListAccounts_DomainRequired(t *testing.T) {
 }
 
 func TestListAccounts_EmailAddrFilter(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.URL.Query().Get("filters[emailaddr]"); got != "alice@example.co.nz" {
-			t.Errorf("filters[emailaddr] = %q, want alice@example.co.nz", got)
+		if got := r.URL.Query().Get("filters[emailaddr]"); got != testEmail {
+			t.Errorf("filters[emailaddr] = %q, want %s", got, testEmail)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":[]}`)
@@ -100,9 +103,9 @@ func TestListAccounts_EmailAddrFilter(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
 	if _, err := New(c).ListAccounts(context.Background(), ListAccountsOptions{
-		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
-		Domain:        "example.co.nz",
-		EmailAddr:     "alice@example.co.nz",
+		ServerOptions: ServerOptions{ServerName: testServerName},
+		Domain:        testDomain,
+		EmailAddr:     testEmail,
 	}); err != nil {
 		t.Fatalf("ListAccounts (filter): %v", err)
 	}

--- a/pkg/api/mail/listaliases.go
+++ b/pkg/api/mail/listaliases.go
@@ -1,0 +1,42 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// ListAliases returns the mail aliases for a domain on the
+// specified mail server via "mail/list_aliases.json". Both
+// ServerName (or NewForServer default) and Domain are required;
+// Source is an optional filter narrowing to a specific source
+// address.
+func (s *Client) ListAliases(ctx context.Context, opt ListAliasesOptions) (response ListAliasesResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.ListAliases: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Domain == "" {
+		return response, fmt.Errorf("mail.ListAliases: Domain is required")
+	}
+	opt.ServerName = server
+
+	u := "mail/list_aliases.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/mail/listaliases_test.go
+++ b/pkg/api/mail/listaliases_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestListAliases_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/list_aliases.json" {
 			t.Errorf("path = %q, want /mail/list_aliases.json", r.URL.Path)
@@ -51,6 +52,7 @@ func TestListAliases_Success(t *testing.T) {
 }
 
 func TestListAliases_DomainRequired(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	_, err := New(c).ListAliases(context.Background(), ListAliasesOptions{
 		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},

--- a/pkg/api/mail/listaliases_test.go
+++ b/pkg/api/mail/listaliases_test.go
@@ -1,0 +1,64 @@
+package mail
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestListAliases_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/list_aliases.json" {
+			t.Errorf("path = %q, want /mail/list_aliases.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("domain"); got != "example.co.nz" {
+			t.Errorf("domain = %q, want example.co.nz", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"return": [
+				{"source": "info@example.co.nz",  "destination": "alice@example.co.nz"},
+				{"source": "sales@example.co.nz", "destination": "bob@example.co.nz"}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).ListAliases(context.Background(), ListAliasesOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Domain:        "example.co.nz",
+	})
+	if err != nil {
+		t.Fatalf("ListAliases: %v", err)
+	}
+	if len(got.Return) != 2 {
+		t.Fatalf("len(Return) = %d, want 2", len(got.Return))
+	}
+	if got.Return[0].Source != "info@example.co.nz" {
+		t.Errorf("Return[0].Source = %q", got.Return[0].Source)
+	}
+	if got.Return[1].Destination != "bob@example.co.nz" {
+		t.Errorf("Return[1].Destination = %q", got.Return[1].Destination)
+	}
+}
+
+func TestListAliases_DomainRequired(t *testing.T) {
+	c, _ := api.New("k", "1")
+	_, err := New(c).ListAliases(context.Background(), ListAliasesOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+	})
+	if err == nil {
+		t.Fatal("expected error for empty Domain, got nil")
+	}
+	if !strings.Contains(err.Error(), "Domain is required") {
+		t.Errorf("error = %q", err.Error())
+	}
+}

--- a/pkg/api/mail/listall.go
+++ b/pkg/api/mail/listall.go
@@ -1,0 +1,48 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// ListAll returns every email-address-shaped record on the named
+// mail server + domain via "mail/list_all.json" — mailboxes,
+// nicknames (aliases), and forwarders, in a single flat list.
+//
+// Distinct from ListAccounts (mailboxes only), ListAliases, and
+// ListForwards: this is the union view, with each entry's Type
+// distinguishing the kind:
+//
+//	type=0  mailbox      Username + EmailAddr + Label
+//	type=1  alias        EmailAddr + Destination
+//	type=2  forward      EmailAddr + Destination
+//
+// Useful for one-shot account-wide audits where you just want
+// "everything pointing at this domain". For typed iteration use the
+// per-kind list endpoints.
+func (s *Client) ListAll(ctx context.Context, opt ListAllOptions) (response ListAllResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.ListAll: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Domain == "" {
+		return response, fmt.Errorf("mail.ListAll: Domain is required")
+	}
+	opt.ServerName = server
+
+	u := "mail/list_all.json"
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/mail/listall_test.go
+++ b/pkg/api/mail/listall_test.go
@@ -1,0 +1,70 @@
+package mail
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestListAll_ParsesUnionTypes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/list_all.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("server_name") != "mail-srv" || q.Get("domain") != "example.com" {
+			t.Errorf("query = %v", q)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status":true,"msg":"Successful.",
+			"return":[
+				{"type":0,"username":"bruce@example.com","emailaddr":"bruce@example.com","label":"Bruce"},
+				{"type":1,"emailaddr":"thomas@example.com","destination":"bruce@example.com"},
+				{"type":2,"emailaddr":"batman@example.com","destination":"bruce@example.com"}
+			]
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).ListAll(context.Background(), ListAllOptions{
+		ServerOptions: ServerOptions{ServerName: "mail-srv"},
+		Domain:        "example.com",
+	})
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if len(got.Return) != 3 {
+		t.Fatalf("expected 3 records, got %d", len(got.Return))
+	}
+	if got.Return[0].Type != 0 || got.Return[0].Username != "bruce@example.com" {
+		t.Errorf("[0] = %+v", got.Return[0])
+	}
+	if got.Return[1].Type != 1 || got.Return[1].Destination != "bruce@example.com" {
+		t.Errorf("[1] = %+v", got.Return[1])
+	}
+	if got.Return[2].Type != 2 || got.Return[2].EmailAddr != "batman@example.com" {
+		t.Errorf("[2] = %+v", got.Return[2])
+	}
+}
+
+func TestListAll_RequiresServerName(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	if _, err := New(c).ListAll(context.Background(), ListAllOptions{Domain: "x.com"}); err == nil {
+		t.Fatal("expected error for missing ServerName")
+	}
+}
+
+func TestListAll_RequiresDomain(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	if _, err := New(c).ListAll(context.Background(), ListAllOptions{
+		ServerOptions: ServerOptions{ServerName: "s"},
+	}); err == nil {
+		t.Fatal("expected error for missing Domain")
+	}
+}

--- a/pkg/api/mail/listall_test.go
+++ b/pkg/api/mail/listall_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestListAll_ParsesUnionTypes(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/list_all.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -54,6 +55,7 @@ func TestListAll_ParsesUnionTypes(t *testing.T) {
 }
 
 func TestListAll_RequiresServerName(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
 	if _, err := New(c).ListAll(context.Background(), ListAllOptions{Domain: "x.com"}); err == nil {
 		t.Fatal("expected error for missing ServerName")
@@ -61,6 +63,7 @@ func TestListAll_RequiresServerName(t *testing.T) {
 }
 
 func TestListAll_RequiresDomain(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
 	if _, err := New(c).ListAll(context.Background(), ListAllOptions{
 		ServerOptions: ServerOptions{ServerName: "s"},

--- a/pkg/api/mail/listdomains.go
+++ b/pkg/api/mail/listdomains.go
@@ -1,0 +1,42 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// ListDomains returns the mail domains configured on the
+// specified mail server via "mail/list_domains.json". ServerName
+// is required, either per-call in opt or via NewForServer.
+//
+// Each entry includes the domain, optional parent domain (for
+// alias domains), catch-all address, state, and per-domain
+// counts of accounts, nicknames (aliases), forwarders, and total
+// addresses in use.
+func (s *Client) ListDomains(ctx context.Context, opt ListDomainsOptions) (response ListDomainsResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.ListDomains: ServerName is required (or set via NewForServer)")
+	}
+	opt.ServerName = server
+
+	u := "mail/list_domains.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/mail/listdomains_test.go
+++ b/pkg/api/mail/listdomains_test.go
@@ -1,0 +1,85 @@
+package mail
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestListDomains_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/list_domains.json" {
+			t.Errorf("path = %q, want /mail/list_domains.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("server_name"); got != "sth-mail-air" {
+			t.Errorf("server_name = %q, want sth-mail-air", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"return": [
+				{
+					"client_id": "1234",
+					"domain": "example.co.nz",
+					"parent_domain": null,
+					"catch_all": "",
+					"state": "1",
+					"accounts": 5,
+					"nicknames": 2,
+					"forwarders": 1,
+					"total_used": 8
+				}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).ListDomains(context.Background(),
+		ListDomainsOptions{ServerOptions: ServerOptions{ServerName: "sth-mail-air"}})
+	if err != nil {
+		t.Fatalf("ListDomains: %v", err)
+	}
+
+	if len(got.Return) != 1 {
+		t.Fatalf("len(Return) = %d, want 1", len(got.Return))
+	}
+	d := got.Return[0]
+	if d.Domain != "example.co.nz" {
+		t.Errorf("Domain = %q, want example.co.nz", d.Domain)
+	}
+	if d.State != "1" {
+		t.Errorf("State = %q, want 1", d.State)
+	}
+	if d.Accounts != 5 {
+		t.Errorf("Accounts = %d, want 5", d.Accounts)
+	}
+	if d.TotalUsed != 8 {
+		t.Errorf("TotalUsed = %d, want 8", d.TotalUsed)
+	}
+}
+
+func TestListDomains_ServerNameRequired(t *testing.T) {
+	c, err := api.New("k", "1")
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	_, err = New(c).ListDomains(context.Background(), ListDomainsOptions{})
+	if err == nil {
+		t.Fatal("expected error for empty ServerName, got nil")
+	}
+	if !strings.Contains(err.Error(), "ServerName is required") {
+		t.Errorf("error = %q, want it to contain 'ServerName is required'", err.Error())
+	}
+}

--- a/pkg/api/mail/listdomains_test.go
+++ b/pkg/api/mail/listdomains_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestListDomains_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/list_domains.json" {
 			t.Errorf("path = %q, want /mail/list_domains.json", r.URL.Path)
@@ -70,6 +71,7 @@ func TestListDomains_Success(t *testing.T) {
 }
 
 func TestListDomains_ServerNameRequired(t *testing.T) {
+	t.Parallel()
 	c, err := api.New("k", "1")
 	if err != nil {
 		t.Fatalf("api.New: %v", err)

--- a/pkg/api/mail/listforwards.go
+++ b/pkg/api/mail/listforwards.go
@@ -1,0 +1,42 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// ListForwards returns the mail forwarders for a domain on the
+// specified mail server via "mail/list_forwards.json". Both
+// ServerName (or NewForServer default) and Domain are required;
+// Source is an optional filter narrowing to a specific source
+// address.
+func (s *Client) ListForwards(ctx context.Context, opt ListForwardsOptions) (response ListForwardsResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.ListForwards: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Domain == "" {
+		return response, fmt.Errorf("mail.ListForwards: Domain is required")
+	}
+	opt.ServerName = server
+
+	u := "mail/list_forwards.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/mail/listforwards_test.go
+++ b/pkg/api/mail/listforwards_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestListForwards_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/list_forwards.json" {
 			t.Errorf("path = %q, want /mail/list_forwards.json", r.URL.Path)
@@ -44,6 +45,7 @@ func TestListForwards_Success(t *testing.T) {
 }
 
 func TestListForwards_DomainRequired(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	_, err := New(c).ListForwards(context.Background(), ListForwardsOptions{
 		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},

--- a/pkg/api/mail/listforwards_test.go
+++ b/pkg/api/mail/listforwards_test.go
@@ -1,0 +1,57 @@
+package mail
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestListForwards_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/list_forwards.json" {
+			t.Errorf("path = %q, want /mail/list_forwards.json", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"return": [
+				{"source": "external@example.co.nz", "destination": "remote@elsewhere.example"}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).ListForwards(context.Background(), ListForwardsOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Domain:        "example.co.nz",
+	})
+	if err != nil {
+		t.Fatalf("ListForwards: %v", err)
+	}
+	if len(got.Return) != 1 {
+		t.Fatalf("len(Return) = %d, want 1", len(got.Return))
+	}
+	if got.Return[0].Destination != "remote@elsewhere.example" {
+		t.Errorf("Return[0].Destination = %q", got.Return[0].Destination)
+	}
+}
+
+func TestListForwards_DomainRequired(t *testing.T) {
+	c, _ := api.New("k", "1")
+	_, err := New(c).ListForwards(context.Background(), ListForwardsOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "Domain is required") {
+		t.Errorf("error = %q", err.Error())
+	}
+}

--- a/pkg/api/mail/models.go
+++ b/pkg/api/mail/models.go
@@ -1,0 +1,45 @@
+package mail
+
+import (
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+type (
+	// Client is a Service to work with the SiteHost Mail API.
+	// defaultServerName, when non-empty, is used as the server_name
+	// for any operation whose request didn't provide one — see
+	// NewForServer.
+	Client struct {
+		client            *api.Client
+		defaultServerName string
+	}
+)
+
+// New returns a Mail client with no captured default server.
+// Every operation must specify the ServerName explicitly in its
+// request options.
+func New(c *api.Client) *Client {
+	return &Client{client: c}
+}
+
+// NewForServer returns a Mail client that captures serverName as
+// the default for every operation. Per-call ServerName values in
+// request options override the captured default; an empty value
+// in the request options falls back to the default.
+//
+// Use this when a consumer only operates against one mail
+// service. For multi-service consumers, prefer New and pass
+// ServerName explicitly on each call.
+func NewForServer(c *api.Client, serverName string) *Client {
+	return &Client{client: c, defaultServerName: serverName}
+}
+
+// resolveServerName picks the per-call value when set, otherwise
+// the captured default. Returns empty if neither is set; callers
+// are expected to validate before issuing the request.
+func (s *Client) resolveServerName(perCall string) string {
+	if perCall != "" {
+		return perCall
+	}
+	return s.defaultServerName
+}

--- a/pkg/api/mail/request.go
+++ b/pkg/api/mail/request.go
@@ -1,0 +1,200 @@
+package mail
+
+type (
+	// ServerOptions identifies a mail server (the API's
+	// server_name parameter). Embedded into operation-specific
+	// option structs. Leave ServerName empty to inherit from a
+	// NewForServer-captured default; otherwise it is required.
+	ServerOptions struct {
+		ServerName string `url:"server_name"`
+	}
+
+	// GetServerInfoOptions identifies the mail server to fetch
+	// info about.
+	GetServerInfoOptions struct {
+		ServerOptions
+	}
+
+	// ListDomainsOptions identifies the mail server whose domains
+	// to list.
+	ListDomainsOptions struct {
+		ServerOptions
+	}
+
+	// GetAccountOptions identifies the mail server and the email
+	// address whose account to fetch.
+	GetAccountOptions struct {
+		ServerOptions
+		Email string `url:"email"`
+	}
+
+	// ListAccountsOptions identifies the mail server and domain
+	// whose accounts to list. EmailAddr is an optional filter
+	// restricting results to a specific address.
+	ListAccountsOptions struct {
+		ServerOptions
+		Domain    string `url:"domain"`
+		EmailAddr string `url:"filters[emailaddr],omitempty"`
+	}
+
+	// ListAllOptions identifies the mail server and domain whose
+	// every-email-record listing to fetch (mailboxes + aliases +
+	// forwarders, in a single union view).
+	ListAllOptions struct {
+		ServerOptions
+		Domain string `url:"domain"`
+	}
+
+	// SearchAccountsOptions identifies the mail server to search
+	// against. At least one of EmailAddr / Username / Active /
+	// Quota should be set; the API rejects calls with no query[*]
+	// filter.
+	SearchAccountsOptions struct {
+		ServerOptions
+		EmailAddr string `url:"query[emailaddr],omitempty"`
+		Username  string `url:"query[username],omitempty"`
+		Active    string `url:"query[active],omitempty"`
+		Quota     string `url:"query[quota],omitempty"`
+		Offset    int    `url:"offsets[offset],omitempty"`
+		Limit     int    `url:"offsets[limit],omitempty"`
+	}
+
+	// ListAliasesOptions identifies the mail server and domain
+	// whose aliases to list. Source is an optional filter
+	// restricting results to a specific source address.
+	ListAliasesOptions struct {
+		ServerOptions
+		Domain string `url:"domain"`
+		Source string `url:"filters[source],omitempty"`
+	}
+
+	// ListForwardsOptions identifies the mail server and domain
+	// whose forwarders to list. Source is an optional filter
+	// restricting results to a specific source address.
+	ListForwardsOptions struct {
+		ServerOptions
+		Domain string `url:"domain"`
+		Source string `url:"filters[source],omitempty"`
+	}
+
+	// SearchAliasesOptions identifies the mail server to search
+	// against for aliases. At least one of Source or Destination
+	// must be set; the API rejects calls with no query[*] filter.
+	SearchAliasesOptions struct {
+		ServerOptions
+		Source      string `url:"query[source],omitempty"`
+		Destination string `url:"query[destination],omitempty"`
+		Offset      int    `url:"offsets[offset],omitempty"`
+		Limit       int    `url:"offsets[limit],omitempty"`
+	}
+
+	// SearchForwardsOptions identifies the mail server to search
+	// against for forwarders. At least one of Source or
+	// Destination must be set.
+	SearchForwardsOptions struct {
+		ServerOptions
+		Source      string `url:"query[source],omitempty"`
+		Destination string `url:"query[destination],omitempty"`
+		Offset      int    `url:"offsets[offset],omitempty"`
+		Limit       int    `url:"offsets[limit],omitempty"`
+	}
+
+	// AccountParams holds the optional per-account settings shared
+	// by AddAccount and UpdateAccount. For AddAccount the
+	// Password field is required.
+	AccountParams struct {
+		Password          string `url:"params[password],omitempty"`
+		Label             string `url:"params[label],omitempty"`
+		Username          string `url:"params[username],omitempty"`
+		Autoresponder     string `url:"params[autoresponder],omitempty"`
+		AutoresponderText string `url:"params[autoresponder_text],omitempty"`
+		SpamStrategy      string `url:"params[spam_strategy],omitempty"`
+		Quota             string `url:"params[quota],omitempty"`
+	}
+
+	// AddAccountOptions describes a new mail account to create.
+	// ServerName, Email, and Password are required; the rest are
+	// optional. (AccountParams is embedded anonymously so its
+	// url:"params[...]" tags are picked up by go-querystring.)
+	AddAccountOptions struct {
+		ServerOptions
+		Email string `url:"email"`
+		AccountParams
+	}
+
+	// UpdateAccountOptions describes an account update. All
+	// AccountParams fields are optional; supplying none is a no-op.
+	UpdateAccountOptions struct {
+		ServerOptions
+		Email string `url:"email"`
+		AccountParams
+	}
+
+	// DeleteAccountOptions identifies the account to delete.
+	DeleteAccountOptions struct {
+		ServerOptions
+		Email string `url:"email"`
+	}
+
+	// AddDomainOptions describes a domain to add to the mail server.
+	AddDomainOptions struct {
+		ServerOptions
+		Domain string `url:"domain"`
+	}
+
+	// DomainParams holds the optional per-domain settings for
+	// UpdateDomain.
+	DomainParams struct {
+		Catchall string `url:"params[catchall],omitempty"`
+		State    string `url:"params[state],omitempty"`
+	}
+
+	// UpdateDomainOptions describes a domain update.
+	UpdateDomainOptions struct {
+		ServerOptions
+		Domain string `url:"domain"`
+		DomainParams
+	}
+
+	// DeleteDomainOptions identifies the domain to remove.
+	DeleteDomainOptions struct {
+		ServerOptions
+		Domain string `url:"domain"`
+	}
+
+	// AliasMapping is the source→destination pair used by add/
+	// delete operations for both aliases and forwarders. Note the
+	// delete operations require both fields — the API rejects
+	// calls with only the source.
+	AliasMapping struct {
+		ServerOptions
+		Source      string `url:"source"`
+		Destination string `url:"destination"`
+	}
+
+	// AddAliasOptions adds an alias mapping.
+	AddAliasOptions = AliasMapping
+
+	// DeleteAliasOptions deletes an alias mapping.
+	DeleteAliasOptions = AliasMapping
+
+	// AddForwardOptions adds a forwarder mapping.
+	AddForwardOptions = AliasMapping
+
+	// DeleteForwardOptions deletes a forwarder mapping.
+	DeleteForwardOptions = AliasMapping
+
+	// AddAliasDomainOptions adds an alias-domain mapping (one
+	// domain pointing at another for mail purposes).
+	AddAliasDomainOptions struct {
+		ServerOptions
+		AliasDomain  string `url:"alias_domain"`
+		ParentDomain string `url:"parent_domain"`
+	}
+
+	// DeleteAliasDomainOptions removes an alias-domain mapping.
+	DeleteAliasDomainOptions struct {
+		ServerOptions
+		AliasDomain string `url:"alias_domain"`
+	}
+)

--- a/pkg/api/mail/response.go
+++ b/pkg/api/mail/response.go
@@ -1,0 +1,188 @@
+package mail
+
+import "github.com/sitehostnz/gosh/pkg/models"
+
+type (
+	// ServerInfo describes a mail server's connection details.
+	ServerInfo struct {
+		Hostname    string `json:"hostname"`
+		WebmailURL  string `json:"webmail_url"`
+		DateAdded   string `json:"date_added"`
+		DateUpdated string `json:"date_updated"`
+	}
+
+	// GetServerInfoResponse represents the response from
+	// get_server_info.
+	GetServerInfoResponse struct {
+		Return ServerInfo `json:"return"`
+		models.APIResponse
+	}
+
+	// Domain is a single mail-domain entry from list_domains.
+	// State is returned as a string ("1" enabled / "0" disabled).
+	// ParentDomain is non-empty for alias domains pointing at
+	// another domain; otherwise empty.
+	// Accounts / Nicknames / Forwarders / TotalUsed are returned
+	// as JSON numbers (so int in Go), distinct from the
+	// string-typed counters elsewhere in the API.
+	Domain struct {
+		ClientID     string `json:"client_id"`
+		Domain       string `json:"domain"`
+		ParentDomain string `json:"parent_domain"`
+		CatchAll     string `json:"catch_all"`
+		State        string `json:"state"`
+		Accounts     int    `json:"accounts"`
+		Nicknames    int    `json:"nicknames"`
+		Forwarders   int    `json:"forwarders"`
+		TotalUsed    int    `json:"total_used"`
+	}
+
+	// ListDomainsResponse represents the response from
+	// list_domains.
+	ListDomainsResponse struct {
+		Return []Domain `json:"return"`
+		models.APIResponse
+	}
+
+	// EmailRecord is a single row from /mail/list_all.json — the
+	// union of mailboxes, aliases, and forwarders. Type
+	// distinguishes the kind:
+	//
+	//   0  mailbox      Username + EmailAddr + Label populated
+	//   1  alias        EmailAddr + Destination populated
+	//   2  forward      EmailAddr + Destination populated
+	//
+	// Fields not relevant to a row's Type deserialise to empty.
+	EmailRecord struct {
+		Type        int    `json:"type"`
+		Username    string `json:"username,omitempty"`
+		EmailAddr   string `json:"emailaddr"`
+		Label       string `json:"label,omitempty"`
+		Destination string `json:"destination,omitempty"`
+	}
+
+	// ListAllResponse is the return from /mail/list_all.json.
+	ListAllResponse struct {
+		Return []EmailRecord `json:"return"`
+		models.APIResponse
+	}
+
+	// Account is a mail account record. Field availability varies
+	// by the source endpoint:
+	//
+	//   - search_accounts populates the first 9 fields only.
+	//   - list_accounts adds QuotaUsed, QuotaPercent, MessageCount,
+	//     LastUpdated.
+	//   - get_account additionally populates Key and DateAdded.
+	//
+	// Fields not populated by an endpoint deserialise to their
+	// zero value (empty string for the string-typed fields). All
+	// numeric / boolean values are returned as strings by the API
+	// ("0", "1", "yes", "no") and represented as Go strings here
+	// for fidelity.
+	Account struct {
+		ClientID         string `json:"client_id"`
+		EmailAddr        string `json:"emailaddr"`
+		Label            string `json:"label"`
+		Username         string `json:"username"`
+		Autoresponder    string `json:"autoresponder"`
+		AutoresponderText string `json:"autoresponder_text"`
+		Active           string `json:"active"`
+		Quota            string `json:"quota"`
+		SpamStrategy     string `json:"spam_strategy"`
+		QuotaUsed        string `json:"quota_used,omitempty"`
+		QuotaPercent     string `json:"quota_percent,omitempty"`
+		MessageCount     string `json:"message_count,omitempty"`
+		LastUpdated      string `json:"last_updated,omitempty"`
+		Key              string `json:"key,omitempty"`
+		DateAdded        string `json:"date_added,omitempty"`
+	}
+
+	// GetAccountResponse represents the response from get_account.
+	GetAccountResponse struct {
+		Return Account `json:"return"`
+		models.APIResponse
+	}
+
+	// ListAccountsResponse represents the response from
+	// list_accounts.
+	ListAccountsResponse struct {
+		Return []Account `json:"return"`
+		models.APIResponse
+	}
+
+	// SearchAccountsResponse represents the response from
+	// search_accounts.
+	SearchAccountsResponse struct {
+		Return []Account `json:"return"`
+		models.APIResponse
+	}
+
+	// Alias is a mail alias mapping (one address redirecting to
+	// another). Aliases are the same data shape as forwards
+	// (source → destination); the type names exist to mirror the
+	// API's separate endpoints.
+	//
+	// ClientID is populated by search_aliases but not by
+	// list_aliases.
+	Alias struct {
+		ClientID    string `json:"client_id,omitempty"`
+		Source      string `json:"source"`
+		Destination string `json:"destination"`
+	}
+
+	// ListAliasesResponse represents the response from
+	// list_aliases.
+	ListAliasesResponse struct {
+		Return []Alias `json:"return"`
+		models.APIResponse
+	}
+
+	// SearchAliasesResponse represents the response from
+	// search_aliases.
+	SearchAliasesResponse struct {
+		Return []Alias `json:"return"`
+		models.APIResponse
+	}
+
+	// Forward is a mail forwarder mapping (a source address
+	// forwarding to a destination, typically external).
+	//
+	// ClientID is populated by search_forwards but not by
+	// list_forwards.
+	Forward struct {
+		ClientID    string `json:"client_id,omitempty"`
+		Source      string `json:"source"`
+		Destination string `json:"destination"`
+	}
+
+	// ListForwardsResponse represents the response from
+	// list_forwards.
+	ListForwardsResponse struct {
+		Return []Forward `json:"return"`
+		models.APIResponse
+	}
+
+	// SearchForwardsResponse represents the response from
+	// search_forwards.
+	SearchForwardsResponse struct {
+		Return []Forward `json:"return"`
+		models.APIResponse
+	}
+
+	// JobResponse is the response shape for the mail write
+	// operations that queue an asynchronous job: AddAccount,
+	// UpdateAccount, DeleteAccount, AddAlias, AddForward. The
+	// returned job ID is for tracking only.
+	//
+	// The other write operations (AddDomain, UpdateDomain,
+	// DeleteDomain, DeleteAlias, DeleteForward, AddAliasDomain,
+	// DeleteAliasDomain) take effect synchronously and return only
+	// models.APIResponse.
+	JobResponse struct {
+		Return struct {
+			models.Job `json:"job"`
+		} `json:"return"`
+		models.APIResponse
+	}
+)

--- a/pkg/api/mail/response.go
+++ b/pkg/api/mail/response.go
@@ -81,21 +81,21 @@ type (
 	// ("0", "1", "yes", "no") and represented as Go strings here
 	// for fidelity.
 	Account struct {
-		ClientID         string `json:"client_id"`
-		EmailAddr        string `json:"emailaddr"`
-		Label            string `json:"label"`
-		Username         string `json:"username"`
-		Autoresponder    string `json:"autoresponder"`
+		ClientID          string `json:"client_id"`
+		EmailAddr         string `json:"emailaddr"`
+		Label             string `json:"label"`
+		Username          string `json:"username"`
+		Autoresponder     string `json:"autoresponder"`
 		AutoresponderText string `json:"autoresponder_text"`
-		Active           string `json:"active"`
-		Quota            string `json:"quota"`
-		SpamStrategy     string `json:"spam_strategy"`
-		QuotaUsed        string `json:"quota_used,omitempty"`
-		QuotaPercent     string `json:"quota_percent,omitempty"`
-		MessageCount     string `json:"message_count,omitempty"`
-		LastUpdated      string `json:"last_updated,omitempty"`
-		Key              string `json:"key,omitempty"`
-		DateAdded        string `json:"date_added,omitempty"`
+		Active            string `json:"active"`
+		Quota             string `json:"quota"`
+		SpamStrategy      string `json:"spam_strategy"`
+		QuotaUsed         string `json:"quota_used,omitempty"`
+		QuotaPercent      string `json:"quota_percent,omitempty"`
+		MessageCount      string `json:"message_count,omitempty"`
+		LastUpdated       string `json:"last_updated,omitempty"`
+		Key               string `json:"key,omitempty"`
+		DateAdded         string `json:"date_added,omitempty"`
 	}
 
 	// GetAccountResponse represents the response from get_account.

--- a/pkg/api/mail/response.go
+++ b/pkg/api/mail/response.go
@@ -49,8 +49,8 @@ type (
 	// distinguishes the kind:
 	//
 	//   0  mailbox      Username + EmailAddr + Label populated
-	//   1  alias        EmailAddr + Destination populated
-	//   2  forward      EmailAddr + Destination populated
+	//   1  forward      EmailAddr + Destination populated
+	//   2  alias        EmailAddr + Destination populated
 	//
 	// Fields not relevant to a row's Type deserialise to empty.
 	EmailRecord struct {

--- a/pkg/api/mail/searchaccounts.go
+++ b/pkg/api/mail/searchaccounts.go
@@ -1,0 +1,43 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// SearchAccounts returns mail accounts on the specified mail
+// server matching the given filters via
+// "mail/search_accounts.json". ServerName (or NewForServer
+// default) is required, plus at least one of EmailAddr,
+// Username, Active, or Quota — the API rejects calls with no
+// query[*] filter.
+func (s *Client) SearchAccounts(ctx context.Context, opt SearchAccountsOptions) (response SearchAccountsResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.SearchAccounts: ServerName is required (or set via NewForServer)")
+	}
+	if opt.EmailAddr == "" && opt.Username == "" && opt.Active == "" && opt.Quota == "" {
+		return response, fmt.Errorf("mail.SearchAccounts: at least one filter (EmailAddr / Username / Active / Quota) is required")
+	}
+	opt.ServerName = server
+
+	u := "mail/search_accounts.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/mail/searchaccounts_test.go
+++ b/pkg/api/mail/searchaccounts_test.go
@@ -1,0 +1,75 @@
+package mail
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestSearchAccounts_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/search_accounts.json" {
+			t.Errorf("path = %q, want /mail/search_accounts.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("query[emailaddr]"); got != "alice@example.co.nz" {
+			t.Errorf("query[emailaddr] = %q, want alice@example.co.nz", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"return": [
+				{
+					"client_id": "1234",
+					"emailaddr": "alice@example.co.nz",
+					"label": "Alice",
+					"username": "alice@example.co.nz",
+					"autoresponder": "0",
+					"autoresponder_text": "",
+					"active": "yes",
+					"quota": "0",
+					"spam_strategy": "0"
+				}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).SearchAccounts(context.Background(), SearchAccountsOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		EmailAddr:     "alice@example.co.nz",
+	})
+	if err != nil {
+		t.Fatalf("SearchAccounts: %v", err)
+	}
+	if len(got.Return) != 1 {
+		t.Fatalf("len(Return) = %d, want 1", len(got.Return))
+	}
+	if got.Return[0].EmailAddr != "alice@example.co.nz" {
+		t.Errorf("EmailAddr = %q", got.Return[0].EmailAddr)
+	}
+	// Search returns the narrower 9-field shape; quota_used / message_count
+	// / last_updated should be empty (zero value).
+	if got.Return[0].QuotaUsed != "" {
+		t.Errorf("QuotaUsed = %q, want empty (search shape doesn't include it)", got.Return[0].QuotaUsed)
+	}
+}
+
+func TestSearchAccounts_FilterRequired(t *testing.T) {
+	c, _ := api.New("k", "1")
+	_, err := New(c).SearchAccounts(context.Background(), SearchAccountsOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+	})
+	if err == nil {
+		t.Fatal("expected error for no filters set, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least one filter") {
+		t.Errorf("error = %q, want it to contain 'at least one filter'", err.Error())
+	}
+}

--- a/pkg/api/mail/searchaccounts_test.go
+++ b/pkg/api/mail/searchaccounts_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestSearchAccounts_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/search_accounts.json" {
 			t.Errorf("path = %q, want /mail/search_accounts.json", r.URL.Path)
@@ -62,6 +63,7 @@ func TestSearchAccounts_Success(t *testing.T) {
 }
 
 func TestSearchAccounts_FilterRequired(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	_, err := New(c).SearchAccounts(context.Background(), SearchAccountsOptions{
 		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},

--- a/pkg/api/mail/searchaliases.go
+++ b/pkg/api/mail/searchaliases.go
@@ -1,0 +1,42 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// SearchAliases returns mail aliases on the specified mail
+// server matching the given filters via
+// "mail/search_aliases.json". ServerName (or NewForServer
+// default) is required, plus at least one of Source or
+// Destination — the API rejects calls with no query[*] filter.
+func (s *Client) SearchAliases(ctx context.Context, opt SearchAliasesOptions) (response SearchAliasesResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.SearchAliases: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Source == "" && opt.Destination == "" {
+		return response, fmt.Errorf("mail.SearchAliases: at least one filter (Source / Destination) is required")
+	}
+	opt.ServerName = server
+
+	u := "mail/search_aliases.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/mail/searchaliases_test.go
+++ b/pkg/api/mail/searchaliases_test.go
@@ -1,0 +1,60 @@
+package mail
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestSearchAliases_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/search_aliases.json" {
+			t.Errorf("path = %q, want /mail/search_aliases.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("query[source]"); got != "info@example.co.nz" {
+			t.Errorf("query[source] = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"return": [
+				{"client_id": "1234", "source": "info@example.co.nz", "destination": "alice@example.co.nz"}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).SearchAliases(context.Background(), SearchAliasesOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Source:        "info@example.co.nz",
+	})
+	if err != nil {
+		t.Fatalf("SearchAliases: %v", err)
+	}
+	if len(got.Return) != 1 {
+		t.Fatalf("len(Return) = %d, want 1", len(got.Return))
+	}
+	if got.Return[0].ClientID != "1234" {
+		t.Errorf("Return[0].ClientID = %q", got.Return[0].ClientID)
+	}
+}
+
+func TestSearchAliases_FilterRequired(t *testing.T) {
+	c, _ := api.New("k", "1")
+	_, err := New(c).SearchAliases(context.Background(), SearchAliasesOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+	})
+	if err == nil {
+		t.Fatal("expected error for no filters, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least one filter") {
+		t.Errorf("error = %q", err.Error())
+	}
+}

--- a/pkg/api/mail/searchaliases_test.go
+++ b/pkg/api/mail/searchaliases_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestSearchAliases_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/search_aliases.json" {
 			t.Errorf("path = %q, want /mail/search_aliases.json", r.URL.Path)
@@ -47,6 +48,7 @@ func TestSearchAliases_Success(t *testing.T) {
 }
 
 func TestSearchAliases_FilterRequired(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	_, err := New(c).SearchAliases(context.Background(), SearchAliasesOptions{
 		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},

--- a/pkg/api/mail/searchforwards.go
+++ b/pkg/api/mail/searchforwards.go
@@ -1,0 +1,42 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// SearchForwards returns mail forwarders on the specified mail
+// server matching the given filters via
+// "mail/search_forwards.json". ServerName (or NewForServer
+// default) is required, plus at least one of Source or
+// Destination — the API rejects calls with no query[*] filter.
+func (s *Client) SearchForwards(ctx context.Context, opt SearchForwardsOptions) (response SearchForwardsResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.SearchForwards: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Source == "" && opt.Destination == "" {
+		return response, fmt.Errorf("mail.SearchForwards: at least one filter (Source / Destination) is required")
+	}
+	opt.ServerName = server
+
+	u := "mail/search_forwards.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/mail/searchforwards_test.go
+++ b/pkg/api/mail/searchforwards_test.go
@@ -1,0 +1,60 @@
+package mail
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestSearchForwards_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/search_forwards.json" {
+			t.Errorf("path = %q, want /mail/search_forwards.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("query[destination]"); got != "remote@elsewhere.example" {
+			t.Errorf("query[destination] = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"return": [
+				{"client_id": "1234", "source": "external@example.co.nz", "destination": "remote@elsewhere.example"}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).SearchForwards(context.Background(), SearchForwardsOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Destination:   "remote@elsewhere.example",
+	})
+	if err != nil {
+		t.Fatalf("SearchForwards: %v", err)
+	}
+	if len(got.Return) != 1 {
+		t.Fatalf("len(Return) = %d, want 1", len(got.Return))
+	}
+	if got.Return[0].Source != "external@example.co.nz" {
+		t.Errorf("Return[0].Source = %q", got.Return[0].Source)
+	}
+}
+
+func TestSearchForwards_FilterRequired(t *testing.T) {
+	c, _ := api.New("k", "1")
+	_, err := New(c).SearchForwards(context.Background(), SearchForwardsOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+	})
+	if err == nil {
+		t.Fatal("expected error for no filters, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least one filter") {
+		t.Errorf("error = %q", err.Error())
+	}
+}

--- a/pkg/api/mail/searchforwards_test.go
+++ b/pkg/api/mail/searchforwards_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestSearchForwards_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/search_forwards.json" {
 			t.Errorf("path = %q, want /mail/search_forwards.json", r.URL.Path)
@@ -47,6 +48,7 @@ func TestSearchForwards_Success(t *testing.T) {
 }
 
 func TestSearchForwards_FilterRequired(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	_, err := New(c).SearchForwards(context.Background(), SearchForwardsOptions{
 		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},

--- a/pkg/api/mail/updateaccount.go
+++ b/pkg/api/mail/updateaccount.go
@@ -1,0 +1,36 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+)
+
+// UpdateAccount updates an existing mail account via
+// "mail/update_account.json". ServerName and Email are required;
+// any non-empty Params field is applied. Supplying no params is
+// a no-op. Returns a JobResponse.
+func (s *Client) UpdateAccount(ctx context.Context, opt UpdateAccountOptions) (response JobResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.UpdateAccount: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Email == "" {
+		return response, fmt.Errorf("mail.UpdateAccount: Email is required")
+	}
+	opt.ServerName = server
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "mail/update_account.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/mail/updatedomain.go
+++ b/pkg/api/mail/updatedomain.go
@@ -1,0 +1,37 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// UpdateDomain updates a mail domain via
+// "mail/update_domain.json". ServerName and Domain are required;
+// Params.Catchall and Params.State (string "0"/"1") are
+// optional. Synchronous; returns models.APIResponse only.
+func (s *Client) UpdateDomain(ctx context.Context, opt UpdateDomainOptions) (response models.APIResponse, err error) {
+	server := s.resolveServerName(opt.ServerName)
+	if server == "" {
+		return response, fmt.Errorf("mail.UpdateDomain: ServerName is required (or set via NewForServer)")
+	}
+	if opt.Domain == "" {
+		return response, fmt.Errorf("mail.UpdateDomain: Domain is required")
+	}
+	opt.ServerName = server
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "mail/update_domain.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/mail/writes_test.go
+++ b/pkg/api/mail/writes_test.go
@@ -1,0 +1,327 @@
+package mail
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+// jobOK is a minimal canned response for write endpoints that
+// return a JobResponse.
+const jobOK = `{"status":true,"msg":"Successful","return":{"job":{"id":42,"type":"daemon"}}}`
+
+// ackOK is a minimal canned response for write endpoints that
+// return only models.APIResponse.
+const ackOK = `{"status":true,"msg":"Successful."}`
+
+// newMockClient spins up an httptest.Server with the given
+// handler and returns a configured api.Client.
+func newMockClient(t *testing.T, h http.HandlerFunc) (*api.Client, func()) {
+	t.Helper()
+	server := httptest.NewServer(h)
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		server.Close()
+		t.Fatalf("api.New: %v", err)
+	}
+	return c, server.Close
+}
+
+func formCheck(t *testing.T, r *http.Request, key, want string) {
+	t.Helper()
+	if got := r.Form.Get(key); got != want {
+		t.Errorf("form[%q] = %q, want %q", key, got, want)
+	}
+}
+
+// --- AddAccount -----------------------------------------------------
+
+func TestAddAccount_Success(t *testing.T) {
+	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/add_account.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = r.ParseForm()
+		formCheck(t, r, "email", "alice@example.co.nz")
+		formCheck(t, r, "params[password]", "secret")
+		formCheck(t, r, "params[label]", "Alice")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	})
+	defer done()
+
+	got, err := New(c).AddAccount(context.Background(), AddAccountOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Email:         "alice@example.co.nz",
+		AccountParams: AccountParams{Password: "secret", Label: "Alice"},
+	})
+	if err != nil {
+		t.Fatalf("AddAccount: %v", err)
+	}
+	if got.Return.Job.ID != 42 {
+		t.Errorf("Job.ID = %d", got.Return.Job.ID)
+	}
+}
+
+func TestAddAccount_RequiredFields(t *testing.T) {
+	c, _ := api.New("k", "1")
+	if _, err := New(c).AddAccount(context.Background(), AddAccountOptions{
+		Email: "x", AccountParams: AccountParams{Password: "p"},
+	}); err == nil || !strings.Contains(err.Error(), "ServerName is required") {
+		t.Errorf("missing ServerName: %v", err)
+	}
+	if _, err := New(c).AddAccount(context.Background(), AddAccountOptions{
+		ServerOptions: ServerOptions{ServerName: "s"}, AccountParams: AccountParams{Password: "p"},
+	}); err == nil || !strings.Contains(err.Error(), "Email is required") {
+		t.Errorf("missing Email: %v", err)
+	}
+	if _, err := New(c).AddAccount(context.Background(), AddAccountOptions{
+		ServerOptions: ServerOptions{ServerName: "s"}, Email: "x",
+	}); err == nil || !strings.Contains(err.Error(), "Password is required") {
+		t.Errorf("missing Password: %v", err)
+	}
+}
+
+// --- UpdateAccount --------------------------------------------------
+
+func TestUpdateAccount_Success(t *testing.T) {
+	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/update_account.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	})
+	defer done()
+
+	if _, err := New(c).UpdateAccount(context.Background(), UpdateAccountOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Email:         "alice@example.co.nz",
+		AccountParams: AccountParams{Label: "Alice (renamed)"},
+	}); err != nil {
+		t.Fatalf("UpdateAccount: %v", err)
+	}
+}
+
+// --- DeleteAccount --------------------------------------------------
+
+func TestDeleteAccount_Success(t *testing.T) {
+	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/delete_account.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = r.ParseForm()
+		formCheck(t, r, "email", "alice@example.co.nz")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	})
+	defer done()
+
+	if _, err := New(c).DeleteAccount(context.Background(), DeleteAccountOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Email:         "alice@example.co.nz",
+	}); err != nil {
+		t.Fatalf("DeleteAccount: %v", err)
+	}
+}
+
+// --- AddDomain ------------------------------------------------------
+
+func TestAddDomain_Success(t *testing.T) {
+	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/add_domain.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = r.ParseForm()
+		formCheck(t, r, "domain", "example.co.nz")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, ackOK)
+	})
+	defer done()
+
+	got, err := New(c).AddDomain(context.Background(), AddDomainOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Domain:        "example.co.nz",
+	})
+	if err != nil {
+		t.Fatalf("AddDomain: %v", err)
+	}
+	if !got.Status {
+		t.Errorf("Status = false")
+	}
+}
+
+// --- UpdateDomain ---------------------------------------------------
+
+func TestUpdateDomain_Catchall(t *testing.T) {
+	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		formCheck(t, r, "params[catchall]", "alice@example.co.nz")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, ackOK)
+	})
+	defer done()
+
+	if _, err := New(c).UpdateDomain(context.Background(), UpdateDomainOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Domain:        "example.co.nz",
+		DomainParams:  DomainParams{Catchall: "alice@example.co.nz"},
+	}); err != nil {
+		t.Fatalf("UpdateDomain: %v", err)
+	}
+}
+
+// --- DeleteDomain ---------------------------------------------------
+
+func TestDeleteDomain_Success(t *testing.T) {
+	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/delete_domain.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, ackOK)
+	})
+	defer done()
+
+	if _, err := New(c).DeleteDomain(context.Background(), DeleteDomainOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Domain:        "example.co.nz",
+	}); err != nil {
+		t.Fatalf("DeleteDomain: %v", err)
+	}
+}
+
+// --- AddAlias / DeleteAlias / AddForward / DeleteForward ------------
+
+func TestAddAlias_Success(t *testing.T) {
+	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/add_alias.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = r.ParseForm()
+		formCheck(t, r, "source", "info@example.co.nz")
+		formCheck(t, r, "destination", "alice@example.co.nz")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	})
+	defer done()
+
+	if _, err := New(c).AddAlias(context.Background(), AddAliasOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Source:        "info@example.co.nz", Destination: "alice@example.co.nz",
+	}); err != nil {
+		t.Fatalf("AddAlias: %v", err)
+	}
+}
+
+func TestDeleteAlias_Success(t *testing.T) {
+	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/delete_alias.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, ackOK)
+	})
+	defer done()
+
+	if _, err := New(c).DeleteAlias(context.Background(), DeleteAliasOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Source:        "info@example.co.nz", Destination: "alice@example.co.nz",
+	}); err != nil {
+		t.Fatalf("DeleteAlias: %v", err)
+	}
+}
+
+func TestDeleteAlias_RequiresBoth(t *testing.T) {
+	c, _ := api.New("k", "1")
+	_, err := New(c).DeleteAlias(context.Background(), DeleteAliasOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Source:        "info@example.co.nz",
+	})
+	if err == nil || !strings.Contains(err.Error(), "Destination is required") {
+		t.Errorf("expected Destination required, got: %v", err)
+	}
+}
+
+func TestAddForward_Success(t *testing.T) {
+	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/add_forward.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	})
+	defer done()
+
+	if _, err := New(c).AddForward(context.Background(), AddForwardOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Source:        "external@example.co.nz", Destination: "remote@elsewhere.example",
+	}); err != nil {
+		t.Fatalf("AddForward: %v", err)
+	}
+}
+
+func TestDeleteForward_Success(t *testing.T) {
+	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/delete_forward.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, ackOK)
+	})
+	defer done()
+
+	if _, err := New(c).DeleteForward(context.Background(), DeleteForwardOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		Source:        "external@example.co.nz", Destination: "remote@elsewhere.example",
+	}); err != nil {
+		t.Fatalf("DeleteForward: %v", err)
+	}
+}
+
+// --- AddAliasDomain / DeleteAliasDomain -----------------------------
+
+func TestAddAliasDomain_Success(t *testing.T) {
+	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/add_alias_domain.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = r.ParseForm()
+		formCheck(t, r, "alias_domain", "alias.example.co.nz")
+		formCheck(t, r, "parent_domain", "example.co.nz")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, ackOK)
+	})
+	defer done()
+
+	if _, err := New(c).AddAliasDomain(context.Background(), AddAliasDomainOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		AliasDomain:   "alias.example.co.nz",
+		ParentDomain:  "example.co.nz",
+	}); err != nil {
+		t.Fatalf("AddAliasDomain: %v", err)
+	}
+}
+
+func TestDeleteAliasDomain_Success(t *testing.T) {
+	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/mail/delete_alias_domain.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, ackOK)
+	})
+	defer done()
+
+	if _, err := New(c).DeleteAliasDomain(context.Background(), DeleteAliasDomainOptions{
+		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
+		AliasDomain:   "alias.example.co.nz",
+	}); err != nil {
+		t.Fatalf("DeleteAliasDomain: %v", err)
+	}
+}

--- a/pkg/api/mail/writes_test.go
+++ b/pkg/api/mail/writes_test.go
@@ -42,6 +42,7 @@ func formCheck(t *testing.T, r *http.Request, key, want string) {
 // --- AddAccount -----------------------------------------------------
 
 func TestAddAccount_Success(t *testing.T) {
+	t.Parallel()
 	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/add_account.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -63,12 +64,13 @@ func TestAddAccount_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AddAccount: %v", err)
 	}
-	if got.Return.Job.ID != 42 {
-		t.Errorf("Job.ID = %d", got.Return.Job.ID)
+	if got.Return.ID != 42 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
 	}
 }
 
 func TestAddAccount_RequiredFields(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	if _, err := New(c).AddAccount(context.Background(), AddAccountOptions{
 		Email: "x", AccountParams: AccountParams{Password: "p"},
@@ -90,6 +92,7 @@ func TestAddAccount_RequiredFields(t *testing.T) {
 // --- UpdateAccount --------------------------------------------------
 
 func TestUpdateAccount_Success(t *testing.T) {
+	t.Parallel()
 	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/update_account.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -111,6 +114,7 @@ func TestUpdateAccount_Success(t *testing.T) {
 // --- DeleteAccount --------------------------------------------------
 
 func TestDeleteAccount_Success(t *testing.T) {
+	t.Parallel()
 	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/delete_account.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -133,6 +137,7 @@ func TestDeleteAccount_Success(t *testing.T) {
 // --- AddDomain ------------------------------------------------------
 
 func TestAddDomain_Success(t *testing.T) {
+	t.Parallel()
 	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/add_domain.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -159,6 +164,7 @@ func TestAddDomain_Success(t *testing.T) {
 // --- UpdateDomain ---------------------------------------------------
 
 func TestUpdateDomain_Catchall(t *testing.T) {
+	t.Parallel()
 	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
 		formCheck(t, r, "params[catchall]", "alice@example.co.nz")
@@ -179,6 +185,7 @@ func TestUpdateDomain_Catchall(t *testing.T) {
 // --- DeleteDomain ---------------------------------------------------
 
 func TestDeleteDomain_Success(t *testing.T) {
+	t.Parallel()
 	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/delete_domain.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -199,6 +206,7 @@ func TestDeleteDomain_Success(t *testing.T) {
 // --- AddAlias / DeleteAlias / AddForward / DeleteForward ------------
 
 func TestAddAlias_Success(t *testing.T) {
+	t.Parallel()
 	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/add_alias.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -220,6 +228,7 @@ func TestAddAlias_Success(t *testing.T) {
 }
 
 func TestDeleteAlias_Success(t *testing.T) {
+	t.Parallel()
 	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/delete_alias.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -238,6 +247,7 @@ func TestDeleteAlias_Success(t *testing.T) {
 }
 
 func TestDeleteAlias_RequiresBoth(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	_, err := New(c).DeleteAlias(context.Background(), DeleteAliasOptions{
 		ServerOptions: ServerOptions{ServerName: "sth-mail-air"},
@@ -249,6 +259,7 @@ func TestDeleteAlias_RequiresBoth(t *testing.T) {
 }
 
 func TestAddForward_Success(t *testing.T) {
+	t.Parallel()
 	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/add_forward.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -267,6 +278,7 @@ func TestAddForward_Success(t *testing.T) {
 }
 
 func TestDeleteForward_Success(t *testing.T) {
+	t.Parallel()
 	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/delete_forward.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -287,6 +299,7 @@ func TestDeleteForward_Success(t *testing.T) {
 // --- AddAliasDomain / DeleteAliasDomain -----------------------------
 
 func TestAddAliasDomain_Success(t *testing.T) {
+	t.Parallel()
 	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/add_alias_domain.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -309,6 +322,7 @@ func TestAddAliasDomain_Success(t *testing.T) {
 }
 
 func TestDeleteAliasDomain_Success(t *testing.T) {
+	t.Parallel()
 	c, done := newMockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/mail/delete_alias_domain.json" {
 			t.Errorf("path = %q", r.URL.Path)


### PR DESCRIPTION
## Summary

Consolidates the full mail namespace. Folds 2 prior per-feature
branches.

Surface:

- Mail domains CRUD
- Mail accounts CRUD
- Aliases + forwards CRUD
- \`mail/list_all\` — union view across the per-type endpoints, with
  doc-comment caveats about per-domain catch-all visibility

## Test plan

- [x] unit tests across the full surface
- [x] live-validated against an owned mail-hosted domain