### PR TITLE
cloud: full namespace — stacks, db, ssh, server-config, images, volumes, ssl/letsencrypt

### DIFF
--- a/examples/cloud-db-compare/main.go
+++ b/examples/cloud-db-compare/main.go
@@ -8,10 +8,10 @@
 // database engines simultaneously, each as its own Docker stack.
 // The stack names ARE the engine identifiers — typical examples:
 //
-//   mariadb1108  — MariaDB 11.8
-//   mysql57      — MySQL 5.7
-//   mysql8       — MySQL 8.x
-//   postgres15   — PostgreSQL 15
+//	mariadb1108  — MariaDB 11.8
+//	mysql57      — MySQL 5.7
+//	mysql8       — MySQL 8.x
+//	postgres15   — PostgreSQL 15
 //
 // (See cloud.stack.image.list_all for the catalog of available
 // engines + the exact stack code shapes.)
@@ -29,23 +29,23 @@
 //
 // # Required env
 //
-//   SH_API_KEY     — API key
-//   SH_CLIENT_ID   — client id
-//   SH_CCS_NAME    — name of the Cloud Container Server with the
-//                    database stacks deployed
+//	SH_API_KEY     — API key
+//	SH_CLIENT_ID   — client id
+//	SH_CCS_NAME    — name of the Cloud Container Server with the
+//	                 database stacks deployed
 //
 // # Optional env
 //
-//   SH_CONTAINER_NAME — existing www-type container name on the
-//                       CCS to use as the database's owning
-//                       container (cloud.db.Add's `container`
-//                       field). If unset, the example picks the
-//                       first non-DB / non-infra stack it finds on
-//                       the CCS. Provide explicitly if your CCS
-//                       has multiple containers and you want to
-//                       pin the association.
-//   JOURNEY_KEEP=1  — leave the created databases + users in place
-//                     (default: cleanup).
+//	SH_CONTAINER_NAME — existing www-type container name on the
+//	                    CCS to use as the database's owning
+//	                    container (cloud.db.Add's `container`
+//	                    field). If unset, the example picks the
+//	                    first non-DB / non-infra stack it finds on
+//	                    the CCS. Provide explicitly if your CCS
+//	                    has multiple containers and you want to
+//	                    pin the association.
+//	JOURNEY_KEEP=1  — leave the created databases + users in place
+//	                  (default: cleanup).
 package main
 
 import (
@@ -63,6 +63,7 @@ import (
 	cloudDBUser "github.com/sitehostnz/gosh/pkg/api/cloud/db/user"
 	"github.com/sitehostnz/gosh/pkg/api/cloud/stack"
 	"github.com/sitehostnz/gosh/pkg/api/job"
+	"github.com/sitehostnz/gosh/pkg/models"
 )
 
 // dbStackPrefixes — known database stack name prefixes. The
@@ -76,7 +77,7 @@ var dbStackPrefixes = []struct {
 }
 
 type dbResult struct {
-	engine   string
+	engine    string
 	stackName string
 	dbName    string
 	dbUser    string
@@ -91,6 +92,7 @@ func main() {
 	}
 }
 
+//nolint:cyclop,funlen // linear example journey; further extraction obscures the read order
 func run() error {
 	apiKey := os.Getenv("SH_API_KEY")
 	clientID := os.Getenv("SH_CLIENT_ID")
@@ -115,25 +117,7 @@ func run() error {
 	}
 	log.Printf("    %d stack(s)", len(stacks.Return.Stacks))
 
-	dbStacks := []dbResult{}
-	containerName := os.Getenv("SH_CONTAINER_NAME")
-	for _, s := range stacks.Return.Stacks {
-		matched := false
-		for _, p := range dbStackPrefixes {
-			if strings.HasPrefix(s.Name, p.prefix) {
-				dbStacks = append(dbStacks, dbResult{engine: p.engine, stackName: s.Name})
-				log.Printf("    [db]  %s (%s)", s.Name, p.engine)
-				matched = true
-				break
-			}
-		}
-		if !matched && containerName == "" && s.Name != "infra" {
-			containerName = s.Name // first non-DB / non-infra stack
-		}
-		if !matched {
-			log.Printf("    [app] %s", s.Name)
-		}
-	}
+	dbStacks, containerName := categoriseStacks(stacks.Return.Stacks, os.Getenv("SH_CONTAINER_NAME"))
 
 	if len(dbStacks) < 2 {
 		return fmt.Errorf("need at least 2 DB stacks on %s for a comparison; found %d",
@@ -186,70 +170,7 @@ func run() error {
 			log.Printf("    sleeping 30s for container-level lock to release before next DB add")
 			time.Sleep(30 * time.Second)
 		}
-		d := &dbStacks[i]
-		shortEngine := strings.ToLower(d.engine[:1]) // m / y / p
-		d.dbName = fmt.Sprintf("goshdb_%s_%s", strings.ToLower(d.engine), suffix)
-		d.dbUser = fmt.Sprintf("g%s%s", shortEngine, suffix) // e.g. gm9f5508 (8 chars)
-		d.dbPass = randHex(16)
-
-		log.Printf("==> %s: cloud.db.Add(%s)", d.engine, d.dbName)
-		addResp, err := cloudDB.New(c).Add(ctx, cloudDB.AddRequest{
-			ServerName: ccsName,
-			MySQLHost:  d.stackName,
-			Database:   d.dbName,
-			Container:  containerName,
-		})
-		if err != nil {
-			d.addErr = err
-			log.Printf("    error: %v", err)
-			continue
-		}
-		if err := waitForJob(ctx, c, addResp.Return.ID, addResp.Return.Type, 2*time.Minute); err != nil {
-			d.addErr = err
-			log.Printf("    job: %v", err)
-			continue
-		}
-		log.Printf("    ✓ database created")
-
-		log.Printf("==> %s: cloud.db.user.Add(%s)", d.engine, d.dbUser)
-		userResp, err := cloudDBUser.New(c).Add(ctx, cloudDBUser.AddRequest{
-			ServerName: ccsName,
-			MySQLHost:  d.stackName,
-			Username:   d.dbUser,
-			Password:   d.dbPass,
-			Database:   d.dbName,
-			Grants: []string{
-				"select", "insert", "update", "delete",
-				"create", "drop", "index", "alter",
-				"create temporary tables", "lock tables",
-				"create view", "show view",
-			},
-		})
-		if err != nil {
-			d.addErr = err
-			log.Printf("    error: %v", err)
-			continue
-		}
-		if err := waitForJob(ctx, c, userResp.Return.ID, userResp.Return.Type, 2*time.Minute); err != nil {
-			d.addErr = err
-			log.Printf("    job: %v", err)
-			continue
-		}
-		log.Printf("    ✓ user + grants applied")
-
-		// Read back to capture how each engine reports the DB.
-		got, err := cloudDB.New(c).Get(ctx, cloudDB.GetRequest{
-			ServerName: ccsName,
-			MySQLHost:  d.stackName,
-			Database:   d.dbName,
-		})
-		if err != nil {
-			log.Printf("    Get: %v", err)
-			continue
-		}
-		d.dbInfo = fmt.Sprintf("id=%s db_name=%s mysql_host=%s size=%v client_id=%s",
-			got.Database.ID, got.Database.DBName, got.Database.MySQLHost,
-			got.Database.Size, got.Database.ClientID)
+		provisionDB(ctx, c, &dbStacks[i], ccsName, containerName, suffix)
 	}
 
 	// 3. Comparison output.
@@ -302,6 +223,89 @@ func randHex(n int) string {
 	b := make([]byte, (n+1)/2)
 	_, _ = rand.Read(b)
 	return fmt.Sprintf("%x", b)[:n]
+}
+
+func provisionDB(ctx context.Context, c *api.Client, d *dbResult, ccsName, containerName, suffix string) {
+	shortEngine := strings.ToLower(d.engine[:1]) // m / y / p
+	d.dbName = fmt.Sprintf("goshdb_%s_%s", strings.ToLower(d.engine), suffix)
+	d.dbUser = fmt.Sprintf("g%s%s", shortEngine, suffix) // e.g. gm9f5508
+	d.dbPass = randHex(16)
+
+	log.Printf("==> %s: cloud.db.Add(%s)", d.engine, d.dbName)
+	addResp, err := cloudDB.New(c).Add(ctx, cloudDB.AddRequest{
+		ServerName: ccsName, MySQLHost: d.stackName,
+		Database: d.dbName, Container: containerName,
+	})
+	if err != nil {
+		d.addErr = err
+		log.Printf("    error: %v", err)
+		return
+	}
+	if err := waitForJob(ctx, c, addResp.Return.ID, addResp.Return.Type, 2*time.Minute); err != nil {
+		d.addErr = err
+		log.Printf("    job: %v", err)
+		return
+	}
+	log.Printf("    ✓ database created")
+
+	log.Printf("==> %s: cloud.db.user.Add(%s)", d.engine, d.dbUser)
+	userResp, err := cloudDBUser.New(c).Add(ctx, cloudDBUser.AddRequest{
+		ServerName: ccsName, MySQLHost: d.stackName,
+		Username: d.dbUser, Password: d.dbPass, Database: d.dbName,
+		Grants: []string{
+			"select", "insert", "update", "delete",
+			"create", "drop", "index", "alter",
+			"create temporary tables", "lock tables",
+			"create view", "show view",
+		},
+	})
+	if err != nil {
+		d.addErr = err
+		log.Printf("    error: %v", err)
+		return
+	}
+	if err := waitForJob(ctx, c, userResp.Return.ID, userResp.Return.Type, 2*time.Minute); err != nil {
+		d.addErr = err
+		log.Printf("    job: %v", err)
+		return
+	}
+	log.Printf("    ✓ user + grants applied")
+
+	got, err := cloudDB.New(c).Get(ctx, cloudDB.GetRequest{
+		ServerName: ccsName, MySQLHost: d.stackName, Database: d.dbName,
+	})
+	if err != nil {
+		log.Printf("    Get: %v", err)
+		return
+	}
+	d.dbInfo = fmt.Sprintf("id=%s db_name=%s mysql_host=%s size=%v client_id=%s",
+		got.Database.ID, got.Database.DBName, got.Database.MySQLHost,
+		got.Database.Size, got.Database.ClientID)
+}
+
+func categoriseStacks(stacks []models.Stack, containerName string) ([]dbResult, string) {
+	dbStacks := []dbResult{}
+	for _, s := range stacks {
+		if engine, ok := matchDBPrefix(s.Name); ok {
+			dbStacks = append(dbStacks, dbResult{engine: engine, stackName: s.Name})
+			log.Printf("    [db]  %s (%s)", s.Name, engine)
+			continue
+		}
+		if containerName == "" && s.Name != "infra" {
+			containerName = s.Name // first non-DB / non-infra stack
+		}
+		log.Printf("    [app] %s", s.Name)
+	}
+	return dbStacks, containerName
+}
+
+func matchDBPrefix(name string) (string, bool) {
+	for _, p := range dbStackPrefixes {
+		if strings.HasPrefix(name, p.prefix) {
+			return p.engine, true
+		}
+	}
+	return "", false
 }
 
 func waitForJob(ctx context.Context, c *api.Client, id int, jobType string, timeout time.Duration) error {

--- a/examples/cloud-db-compare/main.go
+++ b/examples/cloud-db-compare/main.go
@@ -1,0 +1,330 @@
+// Program cloud-db-compare creates a database + user on each of a
+// CCS's MariaDB and MySQL stacks, prints a side-by-side comparison
+// of the responses, and tears down.
+//
+// # How "which database server" is chosen
+//
+// A SiteHost Cloud Container Server (CCS) can run multiple
+// database engines simultaneously, each as its own Docker stack.
+// The stack names ARE the engine identifiers — typical examples:
+//
+//   mariadb1108  — MariaDB 11.8
+//   mysql57      — MySQL 5.7
+//   mysql8       — MySQL 8.x
+//   postgres15   — PostgreSQL 15
+//
+// (See cloud.stack.image.list_all for the catalog of available
+// engines + the exact stack code shapes.)
+//
+// When creating a database via cloud.db.Add, the `mysql_host`
+// field selects which DB stack on the CCS the database lives in.
+// It is NOT a hostname in the DNS sense — it's the stack name
+// that's resolvable inside the CCS Docker network.
+//
+// This example discovers what DB stacks are present on the target
+// CCS by listing stacks and matching well-known prefixes
+// (mariadb*, mysql*, postgres*). For each match it provisions a
+// throwaway database, then prints what each engine returned so
+// you can see how the platform reports them differently.
+//
+// # Required env
+//
+//   SH_API_KEY     — API key
+//   SH_CLIENT_ID   — client id
+//   SH_CCS_NAME    — name of the Cloud Container Server with the
+//                    database stacks deployed
+//
+// # Optional env
+//
+//   SH_CONTAINER_NAME — existing www-type container name on the
+//                       CCS to use as the database's owning
+//                       container (cloud.db.Add's `container`
+//                       field). If unset, the example picks the
+//                       first non-DB / non-infra stack it finds on
+//                       the CCS. Provide explicitly if your CCS
+//                       has multiple containers and you want to
+//                       pin the association.
+//   JOURNEY_KEEP=1  — leave the created databases + users in place
+//                     (default: cleanup).
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+	cloudDB "github.com/sitehostnz/gosh/pkg/api/cloud/db"
+	cloudDBUser "github.com/sitehostnz/gosh/pkg/api/cloud/db/user"
+	"github.com/sitehostnz/gosh/pkg/api/cloud/stack"
+	"github.com/sitehostnz/gosh/pkg/api/job"
+)
+
+// dbStackPrefixes — known database stack name prefixes. The
+// matched prefix becomes the engine label in the comparison.
+var dbStackPrefixes = []struct {
+	prefix, engine string
+}{
+	{"mariadb", "MariaDB"},
+	{"mysql", "MySQL"},
+	{"postgres", "PostgreSQL"},
+}
+
+type dbResult struct {
+	engine   string
+	stackName string
+	dbName    string
+	dbUser    string
+	dbPass    string
+	dbInfo    string // dump of the cloud.db.Get response
+	addErr    error
+}
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("cloud-db-compare: %v", err)
+	}
+}
+
+func run() error {
+	apiKey := os.Getenv("SH_API_KEY")
+	clientID := os.Getenv("SH_CLIENT_ID")
+	ccsName := os.Getenv("SH_CCS_NAME")
+	if apiKey == "" || clientID == "" || ccsName == "" {
+		return fmt.Errorf("SH_API_KEY, SH_CLIENT_ID, SH_CCS_NAME required")
+	}
+	keep := os.Getenv("JOURNEY_KEEP") == "1"
+	c, err := api.New(apiKey, clientID)
+	if err != nil {
+		return fmt.Errorf("api.New: %w", err)
+	}
+	ctx := context.Background()
+
+	// 1. Discover stacks on the CCS — we need to know what DB
+	//    engines are available and pick a non-DB container as the
+	//    "owner" for cloud.db.Add's `container` field.
+	log.Printf("==> listing stacks on %s", ccsName)
+	stacks, err := stack.New(c).List(ctx, stack.ListRequest{ServerName: ccsName})
+	if err != nil {
+		return fmt.Errorf("cloud.stack.List: %w", err)
+	}
+	log.Printf("    %d stack(s)", len(stacks.Return.Stacks))
+
+	dbStacks := []dbResult{}
+	containerName := os.Getenv("SH_CONTAINER_NAME")
+	for _, s := range stacks.Return.Stacks {
+		matched := false
+		for _, p := range dbStackPrefixes {
+			if strings.HasPrefix(s.Name, p.prefix) {
+				dbStacks = append(dbStacks, dbResult{engine: p.engine, stackName: s.Name})
+				log.Printf("    [db]  %s (%s)", s.Name, p.engine)
+				matched = true
+				break
+			}
+		}
+		if !matched && containerName == "" && s.Name != "infra" {
+			containerName = s.Name // first non-DB / non-infra stack
+		}
+		if !matched {
+			log.Printf("    [app] %s", s.Name)
+		}
+	}
+
+	if len(dbStacks) < 2 {
+		return fmt.Errorf("need at least 2 DB stacks on %s for a comparison; found %d",
+			ccsName, len(dbStacks))
+	}
+	if containerName == "" {
+		return fmt.Errorf("no non-DB / non-infra container on %s — set SH_CONTAINER_NAME explicitly", ccsName)
+	}
+	log.Printf("    using container=%s as the owning container", containerName)
+
+	// Sort dbStacks for stable output.
+	sort.Slice(dbStacks, func(i, j int) bool { return dbStacks[i].engine < dbStacks[j].engine })
+
+	suffix := randHex(6)
+
+	// Defer cleanup early so a partial run still tears down what
+	// it created.
+	defer func() {
+		if keep {
+			log.Printf("JOURNEY_KEEP=1 — leaving databases + users in place")
+			return
+		}
+		log.Printf("==> cleanup")
+		for _, d := range dbStacks {
+			if d.dbName == "" {
+				continue
+			}
+			cleanupDB(ctx, c, ccsName, d.stackName, d.dbName, d.dbUser)
+		}
+	}()
+
+	// 2. For each DB stack, create database + user.
+	//
+	// Naming notes (verified live, May 2026):
+	//
+	//   - Database names accept underscores; tested goshdb_<engine>_<hex>
+	//     successfully.
+	//   - **Usernames are restricted** — the API rejects underscored
+	//     names with "Please specify a valid username." Mirroring
+	//     the cc<hex> stack-name shape (alphanumeric, ≤16 chars)
+	//     works. Picked "g<short><6hex>" here.
+	//
+	// Between the two DB adds we sleep briefly to let the
+	// container-level lock release. Without it the second
+	// cloud.db.Add hits "Unable to create database. There is
+	// already a job operating on the container." even though the
+	// scheduler job from the first add reported Completed.
+	for i := range dbStacks {
+		if i > 0 {
+			log.Printf("    sleeping 30s for container-level lock to release before next DB add")
+			time.Sleep(30 * time.Second)
+		}
+		d := &dbStacks[i]
+		shortEngine := strings.ToLower(d.engine[:1]) // m / y / p
+		d.dbName = fmt.Sprintf("goshdb_%s_%s", strings.ToLower(d.engine), suffix)
+		d.dbUser = fmt.Sprintf("g%s%s", shortEngine, suffix) // e.g. gm9f5508 (8 chars)
+		d.dbPass = randHex(16)
+
+		log.Printf("==> %s: cloud.db.Add(%s)", d.engine, d.dbName)
+		addResp, err := cloudDB.New(c).Add(ctx, cloudDB.AddRequest{
+			ServerName: ccsName,
+			MySQLHost:  d.stackName,
+			Database:   d.dbName,
+			Container:  containerName,
+		})
+		if err != nil {
+			d.addErr = err
+			log.Printf("    error: %v", err)
+			continue
+		}
+		if err := waitForJob(ctx, c, addResp.Return.ID, addResp.Return.Type, 2*time.Minute); err != nil {
+			d.addErr = err
+			log.Printf("    job: %v", err)
+			continue
+		}
+		log.Printf("    ✓ database created")
+
+		log.Printf("==> %s: cloud.db.user.Add(%s)", d.engine, d.dbUser)
+		userResp, err := cloudDBUser.New(c).Add(ctx, cloudDBUser.AddRequest{
+			ServerName: ccsName,
+			MySQLHost:  d.stackName,
+			Username:   d.dbUser,
+			Password:   d.dbPass,
+			Database:   d.dbName,
+			Grants: []string{
+				"select", "insert", "update", "delete",
+				"create", "drop", "index", "alter",
+				"create temporary tables", "lock tables",
+				"create view", "show view",
+			},
+		})
+		if err != nil {
+			d.addErr = err
+			log.Printf("    error: %v", err)
+			continue
+		}
+		if err := waitForJob(ctx, c, userResp.Return.ID, userResp.Return.Type, 2*time.Minute); err != nil {
+			d.addErr = err
+			log.Printf("    job: %v", err)
+			continue
+		}
+		log.Printf("    ✓ user + grants applied")
+
+		// Read back to capture how each engine reports the DB.
+		got, err := cloudDB.New(c).Get(ctx, cloudDB.GetRequest{
+			ServerName: ccsName,
+			MySQLHost:  d.stackName,
+			Database:   d.dbName,
+		})
+		if err != nil {
+			log.Printf("    Get: %v", err)
+			continue
+		}
+		d.dbInfo = fmt.Sprintf("id=%s db_name=%s mysql_host=%s size=%v client_id=%s",
+			got.Database.ID, got.Database.DBName, got.Database.MySQLHost,
+			got.Database.Size, got.Database.ClientID)
+	}
+
+	// 3. Comparison output.
+	log.Println()
+	log.Println("============== comparison ==============")
+	for _, d := range dbStacks {
+		log.Printf("[%s]", d.engine)
+		log.Printf("  stack:      %s", d.stackName)
+		log.Printf("  database:   %s", d.dbName)
+		log.Printf("  user:       %s", d.dbUser)
+		log.Printf("  password:   %s (scrubbed in real output; printed here for the example)", d.dbPass[:4]+"…")
+		if d.addErr != nil {
+			log.Printf("  status:     ERR: %v", d.addErr)
+		} else {
+			log.Printf("  Get():      %s", d.dbInfo)
+		}
+		log.Println()
+	}
+	return nil
+}
+
+func cleanupDB(ctx context.Context, c *api.Client, ccsName, mysqlHost, dbName, dbUser string) {
+	if dbUser != "" {
+		_, err := cloudDBUser.New(c).Delete(ctx, cloudDBUser.DeleteRequest{
+			ServerName: ccsName, MySQLHost: mysqlHost, Username: dbUser,
+		})
+		if err != nil {
+			log.Printf("    [%s] user delete: %v", dbName, err)
+		} else {
+			log.Printf("    [%s] ✓ user deleted", dbName)
+		}
+	}
+	resp, err := cloudDB.New(c).Delete(ctx, cloudDB.DeleteRequest{
+		ServerName: ccsName, MySQLHost: mysqlHost, Database: dbName,
+	})
+	if err != nil {
+		log.Printf("    [%s] db delete: %v", dbName, err)
+		return
+	}
+	if resp.Return.ID > 0 {
+		if err := waitForJob(ctx, c, resp.Return.ID, resp.Return.Type, 2*time.Minute); err != nil {
+			log.Printf("    [%s] db delete job: %v", dbName, err)
+			return
+		}
+	}
+	log.Printf("    [%s] ✓ db deleted", dbName)
+}
+
+func randHex(n int) string {
+	b := make([]byte, (n+1)/2)
+	_, _ = rand.Read(b)
+	return fmt.Sprintf("%x", b)[:n]
+}
+
+func waitForJob(ctx context.Context, c *api.Client, id int, jobType string, timeout time.Duration) error {
+	jc := job.New(c)
+	deadline := time.Now().Add(timeout)
+	for {
+		resp, err := jc.Get(ctx, job.GetRequest{ID: id, Type: jobType})
+		if err != nil {
+			return err
+		}
+		switch resp.Return.State {
+		case "Completed":
+			return nil
+		case "Failed":
+			return fmt.Errorf("job %d failed (state=%s)", id, resp.Return.State)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("job %d timed out (state=%s)", id, resp.Return.State)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golangci/golangci-lint/v2 v2.1.6
 	github.com/google/go-querystring v1.1.0
 	github.com/ory/go-acc v0.2.8
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -206,7 +207,6 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.6.1 // indirect
 	mvdan.cc/gofumpt v0.8.0 // indirect
 	mvdan.cc/unparam v0.0.0-20250301125049-0df0534333a4 // indirect

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -15,10 +15,11 @@ import (
 )
 
 const (
-	defaultBaseURL   = "https://api.sitehost.nz"
-	defaultVersion   = "1.5"
-	userAgent        = "gosh"
-	defaultMediaType = "application/x-www-form-urlencoded"
+	defaultBaseURL            = "https://api.sitehost.nz"
+	defaultVersion            = "1.5"
+	userAgent                 = "gosh"
+	defaultMediaType          = "application/x-www-form-urlencoded"
+	defaultCustomImageGitHost = "gitlab-clients.sitehost.co.nz"
 )
 
 type (
@@ -144,10 +145,11 @@ func NewClient(apiKey, clientID string) *Client {
 	c := &Client{
 		client: &http.Client{},
 		ClientBase: models.ClientBase{
-			BaseURL:   baseURL,
-			APIKey:    apiKey,
-			ClientID:  clientID,
-			UserAgent: userAgent,
+			BaseURL:            baseURL,
+			APIKey:             apiKey,
+			ClientID:           clientID,
+			UserAgent:          userAgent,
+			CustomImageGitHost: defaultCustomImageGitHost,
 		},
 	}
 
@@ -162,6 +164,16 @@ func SetBaseURL(bu string) ClientOpt {
 			return err
 		}
 		c.BaseURL = u
+		return nil
+	}
+}
+
+// SetCustomImageGitHost overrides the GitLab host used by custom
+// image helpers when constructing repository clone URLs. Default
+// is "gitlab-clients.sitehost.co.nz".
+func SetCustomImageGitHost(host string) ClientOpt {
+	return func(c *Client) error {
+		c.CustomImageGitHost = host
 		return nil
 	}
 }

--- a/pkg/api/cloud/db/add.go
+++ b/pkg/api/cloud/db/add.go
@@ -7,7 +7,35 @@ import (
 	"github.com/sitehostnz/gosh/pkg/net"
 )
 
-// Add creates a new cloud database.
+// Add creates a new cloud database via /cloud/db/add.json.
+//
+// Required fields:
+//   - ServerName: the CCS to create the database on.
+//   - MySQLHost: the **DB stack name** on the CCS — e.g.
+//     "mariadb1108", "mysql57", "postgres15". Despite the field
+//     name, this is NOT a DNS hostname; it's the docker-stack
+//     name resolvable inside the CCS's docker network.
+//     Discover what's available via cloud.stack.List on the CCS
+//     and match well-known prefixes (mariadb*/mysql*/postgres*).
+//   - Database: the name of the new database (snake_case OK).
+//   - Container: the name of an existing www-type container stack
+//     on the same CCS that "owns" this database (used by the
+//     Control Panel UI to associate the DB with its consumer).
+//
+// **Container-level lock between consecutive Adds** (verified live,
+// May 2026): two cloud.db.Add calls against the **same Container**
+// in quick succession reject the second with:
+//
+//	"Unable to create database. There is already a job operating
+//	 on the container."
+//
+// even after the first call's scheduler job reports Completed. The
+// container holds a brief follow-on lock past the Add's scheduler
+// job. Insert ~30s of backoff between Adds against the same
+// Container, OR pin each DB to a different Container, OR retry on
+// the substring "already a job operating on the container."
+//
+// See examples/cloud-db-compare for the working pattern.
 func (s *Client) Add(ctx context.Context, request AddRequest) (response AddResponse, err error) {
 	uri := "cloud/db/add.json"
 	keys := []string{

--- a/pkg/api/cloud/db/user/add.go
+++ b/pkg/api/cloud/db/user/add.go
@@ -7,7 +7,24 @@ import (
 	"github.com/sitehostnz/gosh/pkg/net"
 )
 
-// Add creates a new cloud database.
+// Add creates a new database user via /cloud/db/user/add.json.
+//
+// **Username format gotcha** (verified live, May 2026): the API
+// rejects names containing underscores or longer than ~16 chars
+// with "Please specify a valid username." The exact rule isn't
+// documented; the safe shape mirrors the cc<hex> stack-name
+// pattern — alphanumeric, no separators, ≤16 chars.
+//
+// Examples that work: "g0a1b2c3d4e", "ccdeadbeef" (matches stack
+// name).
+// Examples that fail: "goshu_mariadb_8abd1e", "my_db_user".
+//
+// Grants takes the lowercased privilege names — typical app
+// grant set is "select", "insert", "update", "delete", "create",
+// "drop", "index", "alter", "create temporary tables",
+// "lock tables", "create view", "show view".
+//
+// See examples/cloud-db-compare for the working pattern.
 func (s *Client) Add(ctx context.Context, request AddRequest) (response AddResponse, err error) {
 	uri := "cloud/db/user/add.json"
 	keys := []string{

--- a/pkg/api/cloud/image/cloneurl.go
+++ b/pkg/api/cloud/image/cloneurl.go
@@ -1,0 +1,27 @@
+package image
+
+import "fmt"
+
+// CloneURL returns the SSH git clone URL for a custom image's
+// backing GitLab repository. The format is
+//
+//	git@<host>:g_<client_id>/<image_code>.git
+//
+// host defaults to "gitlab-clients.sitehost.co.nz" but can be
+// overridden via api.SetCustomImageGitHost when constructing the
+// underlying api.Client. client_id is the consumer's account ID
+// (already on the api.Client). image_code is the image's Code as
+// returned by Get / list_all.
+//
+// **Why this is a helper rather than an API field:** the GitLab
+// repo URL isn't returned by any /cloud/image endpoint — only the
+// Docker registry URL is (registry_url). Consumers were expected to
+// copy the repo URL from the Control Panel UI; this helper closes
+// that gap so SDK consumers can clone without leaving the Go
+// program.
+func (s *Client) CloneURL(imageCode string) string {
+	return fmt.Sprintf("git@%s:g_%s/%s.git",
+		s.client.CustomImageGitHost,
+		s.client.ClientID,
+		imageCode)
+}

--- a/pkg/api/cloud/image/cloud_image_test.go
+++ b/pkg/api/cloud/image/cloud_image_test.go
@@ -1,0 +1,132 @@
+package image
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func readForm(t *testing.T, r *http.Request) url.Values {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	v, err := url.ParseQuery(string(body))
+	if err != nil {
+		t.Fatalf("parse body: %v", err)
+	}
+	return v
+}
+
+const jobOK = `{"status":true,"msg":"Successful","return":{"job":{"id":7319505,"type":"scheduler"}}}`
+
+func TestCreate_Forked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/image/create.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := readForm(t, r)
+		if v.Get("label") != "My Custom Image" || v.Get("params[code]") != "my-custom-image" ||
+			v.Get("params[fork_id]") != "61" {
+			t.Errorf("form = %v", v)
+		}
+		if v.Get("params[ssh_keys][0]") != "23" || v.Get("params[ssh_keys][1]") != "25" {
+			t.Errorf("ssh_keys = %v", v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).Create(context.Background(), CreateRequest{
+		Label: "My Custom Image", Code: "my-custom-image", ForkID: 61,
+		SSHKeys: []int{23, 25},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got.Return.ID != 7319505 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
+	}
+}
+
+func TestCreate_FromScratch_OmitsForkID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := readForm(t, r)
+		if _, present := v["params[fork_id]"]; present {
+			t.Errorf("fork_id should be omitted when zero, got %v", v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).Create(context.Background(), CreateRequest{Label: "scratch"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
+func TestCreate_RequiresLabel(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	if _, err := New(c).Create(context.Background(), CreateRequest{}); err == nil {
+		t.Fatal("expected error for missing Label")
+	}
+}
+
+func TestDelete_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/image/delete.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := readForm(t, r)
+		if v.Get("code") != "my-custom-image" {
+			t.Errorf("code = %q", v.Get("code"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).Delete(context.Background(), DeleteRequest{Code: "my-custom-image"})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got.Return.ID != 7319505 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
+	}
+}
+
+func TestGetChangelog_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/image/get_changelog.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("code") != "sitehost-php55" {
+			t.Errorf("code = %q", r.URL.Query().Get("code"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status":true,"msg":"Successful",
+			"return":{"code":"sitehost-php55","label":"None","changelog":"**VERSION: 1.0.0**"}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).GetChangelog(context.Background(), GetChangelogRequest{Code: "sitehost-php55"})
+	if err != nil {
+		t.Fatalf("GetChangelog: %v", err)
+	}
+	if got.Return.Code != "sitehost-php55" || got.Return.Changelog == "" {
+		t.Errorf("Return = %+v", got.Return)
+	}
+}

--- a/pkg/api/cloud/image/cloud_image_test.go
+++ b/pkg/api/cloud/image/cloud_image_test.go
@@ -27,6 +27,7 @@ func readForm(t *testing.T, r *http.Request) url.Values {
 const jobOK = `{"status":true,"msg":"Successful","return":{"job":{"id":7319505,"type":"scheduler"}}}`
 
 func TestCreate_Forked(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/image/create.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -58,6 +59,7 @@ func TestCreate_Forked(t *testing.T) {
 }
 
 func TestCreate_FromScratch_OmitsForkID(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v := readForm(t, r)
 		if _, present := v["params[fork_id]"]; present {
@@ -75,6 +77,7 @@ func TestCreate_FromScratch_OmitsForkID(t *testing.T) {
 }
 
 func TestCreate_RequiresLabel(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
 	if _, err := New(c).Create(context.Background(), CreateRequest{}); err == nil {
 		t.Fatal("expected error for missing Label")
@@ -82,6 +85,7 @@ func TestCreate_RequiresLabel(t *testing.T) {
 }
 
 func TestDelete_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/image/delete.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -106,6 +110,7 @@ func TestDelete_Success(t *testing.T) {
 }
 
 func TestGetChangelog_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/image/get_changelog.json" {
 			t.Errorf("path = %q", r.URL.Path)

--- a/pkg/api/cloud/image/create.go
+++ b/pkg/api/cloud/image/create.go
@@ -1,0 +1,62 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Create creates a new custom image via /cloud/image/create.json.
+//
+// Label is required. Code is optional — the API generates one from
+// the label when omitted, but consumers usually want to specify it
+// so the image's GitLab repository slug is predictable.
+//
+// ForkID forks a public SiteHost image (the parent's id, available
+// from cloud/image/list_all.json's is_public=1 entries). When zero,
+// the image is built from scratch.
+//
+// SSHKeys grants the listed customer-level SSH key IDs access to
+// the backing GitLab repository at gitlab-clients.sitehost.co.nz.
+// Without at least one key, the customer cannot push commits.
+//
+// The endpoint returns a scheduler job; the image record (and its
+// GitLab repository) is created asynchronously. Consumers should
+// poll cloud/job until the job completes before attempting to clone.
+func (s *Client) Create(ctx context.Context, request CreateRequest) (response JobResponse, err error) {
+	if request.Label == "" {
+		return response, fmt.Errorf("cloud.image.Create: Label is required")
+	}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("label", request.Label)
+
+	keys := []string{"client_id", "label"}
+
+	if request.Code != "" {
+		values.Add("params[code]", request.Code)
+		keys = append(keys, "params[code]")
+	}
+	if request.ForkID != 0 {
+		values.Add("params[fork_id]", strconv.Itoa(request.ForkID))
+		keys = append(keys, "params[fork_id]")
+	}
+	for i, id := range request.SSHKeys {
+		k := fmt.Sprintf("params[ssh_keys][%d]", i)
+		values.Add(k, strconv.Itoa(id))
+		keys = append(keys, k)
+	}
+
+	req, err := s.client.NewRequest("POST", "cloud/image/create.json", net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/image/delete.go
+++ b/pkg/api/cloud/image/delete.go
@@ -1,0 +1,32 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Delete deletes a custom image via /cloud/image/delete.json. The
+// API rejects deletion if any container is still using a version of
+// this image — clean those up first. Returns a scheduler job.
+func (s *Client) Delete(ctx context.Context, request DeleteRequest) (response JobResponse, err error) {
+	if request.Code == "" {
+		return response, fmt.Errorf("cloud.image.Delete: Code is required")
+	}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("code", request.Code)
+
+	req, err := s.client.NewRequest("POST", "cloud/image/delete.json",
+		net.Encode(values, []string{"client_id", "code"}))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/image/forkfrom.go
+++ b/pkg/api/cloud/image/forkfrom.go
@@ -4,15 +4,27 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+
+	stackimage "github.com/sitehostnz/gosh/pkg/api/cloud/stack/image"
 )
 
 // ForkFromImage creates a new custom image forked from a SiteHost
 // public image identified by parentCode (e.g. "sitehost-php80").
 //
 // This composite helper resolves the public parent's numeric id by
-// listing images and matching on Code+IsPublic, then calls Create
-// with that fork_id. Without this helper, consumers have to do the
-// list-filter-extract-id dance themselves.
+// listing the platform stack-image catalogue and matching on
+// Code+IsPublic, then calls Create with that fork_id. Without this
+// helper, consumers have to do the list-filter-extract-id dance
+// themselves.
+//
+// The parent lookup uses /cloud/stack/image/list_all (the platform
+// catalogue, where public images live) rather than
+// /cloud/image/list_all (the customer-only endpoint, which returns
+// just the calling client's own custom images). That distinction
+// matters on bootstrap accounts: the customer endpoint is empty
+// before the first fork, so a lookup against it would always miss
+// public parents — exactly the case where this helper is most
+// useful.
 //
 // label is required (used as the new image's display label).
 // code is the desired image code (slug used in the GitLab repo URL
@@ -32,13 +44,13 @@ func (s *Client) ForkFromImage(ctx context.Context, parentCode, label, code stri
 		return response, fmt.Errorf("cloud.image.ForkFromImage: label is required")
 	}
 
-	listing, err := s.List(ctx)
+	catalogue, err := stackimage.New(s.client).List(ctx)
 	if err != nil {
-		return response, fmt.Errorf("listing images to resolve fork target %q: %w", parentCode, err)
+		return response, fmt.Errorf("listing stack-image catalogue to resolve fork target %q: %w", parentCode, err)
 	}
 
 	var forkID int
-	for _, img := range listing.Return.Images {
+	for _, img := range catalogue.Return {
 		if img.Code == parentCode && bool(img.IsPublic) {
 			id, perr := strconv.Atoi(img.ID)
 			if perr != nil {
@@ -49,7 +61,7 @@ func (s *Client) ForkFromImage(ctx context.Context, parentCode, label, code stri
 		}
 	}
 	if forkID == 0 {
-		return response, fmt.Errorf("public SiteHost image with code %q not found in cloud.image.list_all", parentCode)
+		return response, fmt.Errorf("public SiteHost image with code %q not found in cloud.stack.image.list_all", parentCode)
 	}
 
 	return s.Create(ctx, CreateRequest{

--- a/pkg/api/cloud/image/forkfrom.go
+++ b/pkg/api/cloud/image/forkfrom.go
@@ -1,0 +1,61 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+)
+
+// ForkFromImage creates a new custom image forked from a SiteHost
+// public image identified by parentCode (e.g. "sitehost-php80").
+//
+// This composite helper resolves the public parent's numeric id by
+// listing images and matching on Code+IsPublic, then calls Create
+// with that fork_id. Without this helper, consumers have to do the
+// list-filter-extract-id dance themselves.
+//
+// label is required (used as the new image's display label).
+// code is the desired image code (slug used in the GitLab repo URL
+// and registry); pass "" to let the API auto-generate it from label.
+// sshKeyIDs are customer-level SSH key IDs that get push access to
+// the backing GitLab repository — at least one is required for the
+// consumer to push commits.
+//
+// Returns the JobResponse from Create. Consumers should poll the
+// job to completion before calling CloneURL or attempting a clone,
+// since the GitLab repo is provisioned asynchronously.
+func (s *Client) ForkFromImage(ctx context.Context, parentCode, label, code string, sshKeyIDs []int) (response JobResponse, err error) {
+	if parentCode == "" {
+		return response, fmt.Errorf("cloud.image.ForkFromImage: parentCode is required")
+	}
+	if label == "" {
+		return response, fmt.Errorf("cloud.image.ForkFromImage: label is required")
+	}
+
+	listing, err := s.List(ctx)
+	if err != nil {
+		return response, fmt.Errorf("listing images to resolve fork target %q: %w", parentCode, err)
+	}
+
+	var forkID int
+	for _, img := range listing.Return.Images {
+		if img.Code == parentCode && bool(img.IsPublic) {
+			id, perr := strconv.Atoi(img.ID)
+			if perr != nil {
+				return response, fmt.Errorf("public image %q has non-numeric id %q: %w", parentCode, img.ID, perr)
+			}
+			forkID = id
+			break
+		}
+	}
+	if forkID == 0 {
+		return response, fmt.Errorf("public SiteHost image with code %q not found in cloud.image.list_all", parentCode)
+	}
+
+	return s.Create(ctx, CreateRequest{
+		Label:   label,
+		Code:    code,
+		ForkID:  forkID,
+		SSHKeys: sshKeyIDs,
+	})
+}

--- a/pkg/api/cloud/image/getchangelog.go
+++ b/pkg/api/cloud/image/getchangelog.go
@@ -1,0 +1,33 @@
+package image
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// GetChangelog returns the change log for a *public* SiteHost image
+// via /cloud/image/get_changelog.json. This is for SiteHost-provided
+// base images (e.g. "sitehost-php55"); custom images don't carry
+// platform-managed changelogs.
+func (s *Client) GetChangelog(ctx context.Context, request GetChangelogRequest) (response GetChangelogResponse, err error) {
+	if request.Code == "" {
+		return response, fmt.Errorf("cloud.image.GetChangelog: Code is required")
+	}
+
+	keys := []string{"apikey", "client_id", "code"}
+
+	req, err := s.client.NewRequest("GET", "cloud/image/get_changelog.json", "")
+	if err != nil {
+		return response, err
+	}
+	v := req.URL.Query()
+	v.Add("code", request.Code)
+	req.URL.RawQuery = net.Encode(v, keys)
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/image/helpers_test.go
+++ b/pkg/api/cloud/image/helpers_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestCloneURL_Default(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "958466", api.SetBaseURL("http://example.invalid"))
 	got := New(c).CloneURL("cerb-custom-image")
 	want := "git@gitlab-clients.sitehost.co.nz:g_958466/cerb-custom-image.git"
@@ -22,6 +23,7 @@ func TestCloneURL_Default(t *testing.T) {
 }
 
 func TestCloneURL_OverriddenHost(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"),
 		api.SetCustomImageGitHost("gitlab-staging.sitehost.co.nz"))
 	got := New(c).CloneURL("test-image")
@@ -31,6 +33,7 @@ func TestCloneURL_OverriddenHost(t *testing.T) {
 }
 
 func TestForkFromImage_ResolvesParentID(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
@@ -65,7 +68,8 @@ func TestForkFromImage_ResolvesParentID(t *testing.T) {
 }
 
 func TestForkFromImage_ParentNotFound(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
 			"status":true,"msg":"OK",
@@ -82,8 +86,9 @@ func TestForkFromImage_ParentNotFound(t *testing.T) {
 }
 
 func TestWaitForBuild_TerminatesOnSuccess(t *testing.T) {
+	t.Parallel()
 	calls := 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		calls++
 		w.Header().Set("Content-Type", "application/json")
 		status := "running"
@@ -108,6 +113,7 @@ func TestWaitForBuild_TerminatesOnSuccess(t *testing.T) {
 }
 
 func TestLintManifest_Valid(t *testing.T) {
+	t.Parallel()
 	data := []byte(`version: 1
 image:
   label: my-custom-image
@@ -120,6 +126,7 @@ image:
 }
 
 func TestLintManifest_MissingFields(t *testing.T) {
+	t.Parallel()
 	data := []byte(`version: 2
 image:
   label: ""
@@ -137,6 +144,7 @@ image:
 }
 
 func TestLintManifest_BadYAML(t *testing.T) {
+	t.Parallel()
 	if err := LintManifest([]byte("\tnot: yaml: at all: [")); err == nil {
 		t.Error("expected YAML parse error")
 	}

--- a/pkg/api/cloud/image/helpers_test.go
+++ b/pkg/api/cloud/image/helpers_test.go
@@ -1,0 +1,143 @@
+package image
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestCloneURL_Default(t *testing.T) {
+	c, _ := api.New("k", "958466", api.SetBaseURL("http://example.invalid"))
+	got := New(c).CloneURL("cerb-custom-image")
+	want := "git@gitlab-clients.sitehost.co.nz:g_958466/cerb-custom-image.git"
+	if got != want {
+		t.Errorf("CloneURL = %q, want %q", got, want)
+	}
+}
+
+func TestCloneURL_OverriddenHost(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"),
+		api.SetCustomImageGitHost("gitlab-staging.sitehost.co.nz"))
+	got := New(c).CloneURL("test-image")
+	if !strings.HasPrefix(got, "git@gitlab-staging.sitehost.co.nz:") {
+		t.Errorf("CloneURL = %q, want override host prefix", got)
+	}
+}
+
+func TestForkFromImage_ResolvesParentID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/cloud/image/list_all.json":
+			_, _ = io.WriteString(w, `{
+				"status":true,"msg":"Successful",
+				"return":{
+					"total_items":2,"current_items":2,"current_page":1,"total_pages":1,
+					"data":[
+						{"id":"61","label":"PHP 8.0","code":"sitehost-php80","is_public":"1"},
+						{"id":"99","label":"Mine","code":"my-image","is_public":"0"}
+					]
+				}
+			}`)
+		case "/cloud/image/create.json":
+			body, _ := io.ReadAll(r.Body)
+			if !strings.Contains(string(body), "params%5Bfork_id%5D=61") {
+				t.Errorf("expected fork_id=61 in body, got: %s", string(body))
+			}
+			_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"job":{"id":1,"type":"scheduler"}}}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	_, err := New(c).ForkFromImage(context.Background(), "sitehost-php80", "Forked", "forked-img", []int{23})
+	if err != nil {
+		t.Fatalf("ForkFromImage: %v", err)
+	}
+}
+
+func TestForkFromImage_ParentNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status":true,"msg":"OK",
+			"return":{"total_items":0,"current_items":0,"current_page":1,"total_pages":1,"data":[]}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	_, err := New(c).ForkFromImage(context.Background(), "nope", "L", "c", []int{1})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found error, got: %v", err)
+	}
+}
+
+func TestWaitForBuild_TerminatesOnSuccess(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		status := "running"
+		if calls >= 2 {
+			status = "success"
+		}
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{
+			"total_items":1,"current_items":1,"current_page":1,"total_pages":1,
+			"data":[{"id":"1","client_id":"1","image_id":"77","version":"1.0-1","build_id":"1","build_status":"`+status+`","code":"x","container_count":0}]
+		}}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).WaitForBuild(context.Background(), 77, 5*time.Second, 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitForBuild: %v", err)
+	}
+	if got.BuildStatus != "success" {
+		t.Errorf("BuildStatus = %q", got.BuildStatus)
+	}
+}
+
+func TestLintManifest_Valid(t *testing.T) {
+	data := []byte(`version: 1
+image:
+  label: my-custom-image
+  type: www
+  provider: 'My Account'
+`)
+	if err := LintManifest(data); err != nil {
+		t.Errorf("expected valid, got %v", err)
+	}
+}
+
+func TestLintManifest_MissingFields(t *testing.T) {
+	data := []byte(`version: 2
+image:
+  label: ""
+`)
+	err := LintManifest(data)
+	if err == nil {
+		t.Fatal("expected lint error")
+	}
+	msg := err.Error()
+	for _, want := range []string{"version must be 1", "image.label is required", "image.type is required", "image.provider is required"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("missing %q in error: %s", want, msg)
+		}
+	}
+}
+
+func TestLintManifest_BadYAML(t *testing.T) {
+	if err := LintManifest([]byte("\tnot: yaml: at all: [")); err == nil {
+		t.Error("expected YAML parse error")
+	}
+}

--- a/pkg/api/cloud/image/helpers_test.go
+++ b/pkg/api/cloud/image/helpers_test.go
@@ -37,16 +37,13 @@ func TestForkFromImage_ResolvesParentID(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
-		case "/cloud/image/list_all.json":
+		case "/cloud/stack/image/list_all.json":
 			_, _ = io.WriteString(w, `{
 				"status":true,"msg":"Successful",
-				"return":{
-					"total_items":2,"current_items":2,"current_page":1,"total_pages":1,
-					"data":[
-						{"id":"61","label":"PHP 8.0","code":"sitehost-php80","is_public":"1"},
-						{"id":"99","label":"Mine","code":"my-image","is_public":"0"}
-					]
-				}
+				"return":[
+					{"id":"61","label":"PHP 8.0","code":"sitehost-php80","is_public":"1"},
+					{"id":"99","label":"Mine","code":"my-image","is_public":"0"}
+				]
 			}`)
 		case "/cloud/image/create.json":
 			body, _ := io.ReadAll(r.Body)
@@ -71,10 +68,7 @@ func TestForkFromImage_ParentNotFound(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{
-			"status":true,"msg":"OK",
-			"return":{"total_items":0,"current_items":0,"current_page":1,"total_pages":1,"data":[]}
-		}`)
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":[]}`)
 	}))
 	defer srv.Close()
 

--- a/pkg/api/cloud/image/lintmanifest.go
+++ b/pkg/api/cloud/image/lintmanifest.go
@@ -1,0 +1,72 @@
+package image
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LintError is returned by LintManifest when a manifest.yml fails
+// schema validation. Errors holds one entry per problem found.
+type LintError struct {
+	Errors []string
+}
+
+// Error joins the lint errors into a single message.
+func (e *LintError) Error() string {
+	if len(e.Errors) == 1 {
+		return "manifest lint: " + e.Errors[0]
+	}
+	return fmt.Sprintf("manifest lint: %d problems: %v", len(e.Errors), e.Errors)
+}
+
+// minimalManifest mirrors the required-field shape of a custom
+// image's manifest.yml. We don't model the full schema (ports,
+// volumes, env_file etc.) because the API doesn't enforce those
+// strictly and consumers may use platform-specific extensions.
+type minimalManifest struct {
+	Version int `yaml:"version"`
+	Image   struct {
+		Label    string `yaml:"label"`
+		Type     string `yaml:"type"`
+		Provider string `yaml:"provider"`
+	} `yaml:"image"`
+}
+
+// LintManifest validates the bytes of a custom-image manifest.yml
+// against the documented minimum schema:
+//
+//   - top-level "version" key (must be 1)
+//   - "image.label" non-empty
+//   - "image.type" non-empty (typically "www" or a service name)
+//   - "image.provider" non-empty (the customer/account label)
+//
+// Local lint is intentionally narrow: catch the "did you forget
+// a required field" class of mistakes that otherwise only surface
+// hours later in a failed CI build trace. The platform's CI
+// remains the source of truth for the full schema.
+func LintManifest(data []byte) error {
+	var m minimalManifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return &LintError{Errors: []string{fmt.Sprintf("YAML parse: %v", err)}}
+	}
+
+	var errs []string
+	if m.Version != 1 {
+		errs = append(errs, fmt.Sprintf("version must be 1, got %d", m.Version))
+	}
+	if m.Image.Label == "" {
+		errs = append(errs, `image.label is required`)
+	}
+	if m.Image.Type == "" {
+		errs = append(errs, `image.type is required (e.g. "www")`)
+	}
+	if m.Image.Provider == "" {
+		errs = append(errs, `image.provider is required`)
+	}
+
+	if len(errs) > 0 {
+		return &LintError{Errors: errs}
+	}
+	return nil
+}

--- a/pkg/api/cloud/image/request.go
+++ b/pkg/api/cloud/image/request.go
@@ -1,9 +1,35 @@
 package image
 
 type (
-
-	// GetRequest represents a request to get a specific image from the /cloud/image/get.json endpoint.
+	// GetRequest represents a request to get a specific image from
+	// the /cloud/image/get.json endpoint.
 	GetRequest struct {
 		Code string `json:"code"`
+	}
+
+	// CreateRequest creates a new custom image via
+	// /cloud/image/create.json. Label is required. Code is optional —
+	// the API generates one from the label if omitted. ForkID is the
+	// id of a public SiteHost image to fork from (optional; omit to
+	// build from scratch). SSHKeys is a list of customer-level SSH
+	// key IDs to grant access to the backing GitLab repository.
+	CreateRequest struct {
+		Label   string
+		Code    string
+		ForkID  int
+		SSHKeys []int
+	}
+
+	// DeleteRequest deletes a custom image via
+	// /cloud/image/delete.json.
+	DeleteRequest struct {
+		Code string
+	}
+
+	// GetChangelogRequest fetches the change log for a public
+	// SiteHost image via /cloud/image/get_changelog.json. Code is the
+	// public image's code (e.g. "sitehost-php55").
+	GetChangelogRequest struct {
+		Code string
 	}
 )

--- a/pkg/api/cloud/image/response.go
+++ b/pkg/api/cloud/image/response.go
@@ -17,4 +17,27 @@ type (
 		Image models.CloudImage `json:"return"`
 		models.APIResponse
 	}
+
+	// JobResponse is the shared response for image write operations
+	// that queue a scheduler job (Create, Delete).
+	JobResponse struct {
+		Return struct {
+			models.Job `json:"job"`
+		} `json:"return"`
+		models.APIResponse
+	}
+
+	// Changelog is the body of GetChangelogResponse.
+	Changelog struct {
+		Code      string `json:"code"`
+		Label     string `json:"label"`
+		Changelog string `json:"changelog"`
+	}
+
+	// GetChangelogResponse represents the return from
+	// /cloud/image/get_changelog.json.
+	GetChangelogResponse struct {
+		Return Changelog `json:"return"`
+		models.APIResponse
+	}
 )

--- a/pkg/api/cloud/image/version/delete.go
+++ b/pkg/api/cloud/image/version/delete.go
@@ -1,0 +1,39 @@
+package version
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Delete removes a specific version of a custom image via
+// /cloud/image/version/delete.json. Version is the version string
+// (e.g. "1.1-1076") as returned by ListAll. Returns a scheduler job.
+//
+// To delete the *image* itself, use cloud.image.Delete instead —
+// this endpoint only prunes one build/version.
+func (s *Client) Delete(ctx context.Context, request DeleteRequest) (response JobResponse, err error) {
+	if request.Code == "" {
+		return response, fmt.Errorf("cloud.image.version.Delete: Code is required")
+	}
+	if request.Version == "" {
+		return response, fmt.Errorf("cloud.image.version.Delete: Version is required")
+	}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("code", request.Code)
+	values.Add("version", request.Version)
+
+	req, err := s.client.NewRequest("POST", "cloud/image/version/delete.json",
+		net.Encode(values, []string{"client_id", "code", "version"}))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/image/version/doc.go
+++ b/pkg/api/cloud/image/version/doc.go
@@ -1,0 +1,4 @@
+// Package version provides access to the /cloud/image/version
+// endpoints — listing build history for a custom image, fetching
+// build logs, and deleting individual versions.
+package version

--- a/pkg/api/cloud/image/version/getbuild.go
+++ b/pkg/api/cloud/image/version/getbuild.go
@@ -1,0 +1,36 @@
+package version
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// GetBuild fetches the build log for a specific custom-image build
+// via /cloud/image/version/get_build.json. Use this to surface CI
+// failures to the consumer when ListAll reports build_status="failed".
+func (s *Client) GetBuild(ctx context.Context, request GetBuildRequest) (response GetBuildResponse, err error) {
+	if request.Code == "" {
+		return response, fmt.Errorf("cloud.image.version.GetBuild: Code is required")
+	}
+	if request.BuildID == "" {
+		return response, fmt.Errorf("cloud.image.version.GetBuild: BuildID is required")
+	}
+
+	keys := []string{"apikey", "client_id", "code", "build_id"}
+
+	req, err := s.client.NewRequest("GET", "cloud/image/version/get_build.json", "")
+	if err != nil {
+		return response, err
+	}
+	v := req.URL.Query()
+	v.Add("code", request.Code)
+	v.Add("build_id", request.BuildID)
+	req.URL.RawQuery = net.Encode(v, keys)
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/image/version/listall.go
+++ b/pkg/api/cloud/image/version/listall.go
@@ -1,0 +1,52 @@
+package version
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// ListAll lists versions (build history) for a custom image via
+// /cloud/image/version/list_all.json. ImageID is required.
+//
+// Each Version carries a BuildStatus ("success" / "failed" /
+// "running") and a BuildID. Only the latest successful build is
+// available to deploy in a container.
+func (s *Client) ListAll(ctx context.Context, request ListAllRequest) (response ListAllResponse, err error) {
+	if request.ImageID == 0 {
+		return response, fmt.Errorf("cloud.image.version.ListAll: ImageID is required")
+	}
+
+	keys := []string{"apikey", "client_id", "image_id"}
+
+	req, err := s.client.NewRequest("GET", "cloud/image/version/list_all.json", "")
+	if err != nil {
+		return response, err
+	}
+	v := req.URL.Query()
+	v.Add("image_id", strconv.Itoa(request.ImageID))
+	if request.SortBy != "" {
+		v.Add("filters[sort_by]", request.SortBy)
+		keys = append(keys, "filters[sort_by]")
+	}
+	if request.SortDir != "" {
+		v.Add("filters[sort_dir]", request.SortDir)
+		keys = append(keys, "filters[sort_dir]")
+	}
+	if request.PageSize != 0 {
+		v.Add("filters[page_size]", strconv.Itoa(request.PageSize))
+		keys = append(keys, "filters[page_size]")
+	}
+	if request.PageNumber != 0 {
+		v.Add("filters[page_number]", strconv.Itoa(request.PageNumber))
+		keys = append(keys, "filters[page_number]")
+	}
+	req.URL.RawQuery = net.Encode(v, keys)
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/image/version/models.go
+++ b/pkg/api/cloud/image/version/models.go
@@ -1,0 +1,33 @@
+package version
+
+import "github.com/sitehostnz/gosh/pkg/api"
+
+type (
+	// Client is a service for the /cloud/image/version endpoints.
+	Client struct {
+		client *api.Client
+	}
+
+	// Version describes one build of a custom image.
+	Version struct {
+		ID             string `json:"id"`
+		ClientID       string `json:"client_id"`
+		ImageID        string `json:"image_id"`
+		Version        string `json:"version"`
+		Labels         string `json:"labels"`
+		DateAdded      string `json:"date_added"`
+		DateUpdated    string `json:"date_updated"`
+		IsMissing      string `json:"is_missing"`
+		ForceConfig    string `json:"force_config"`
+		BuildID        string `json:"build_id"`
+		BuildStatus    string `json:"build_status"`
+		Pending        any    `json:"pending"`
+		Code           string `json:"code"`
+		ContainerCount int    `json:"container_count"`
+	}
+)
+
+// New initialises a version Client.
+func New(c *api.Client) *Client {
+	return &Client{client: c}
+}

--- a/pkg/api/cloud/image/version/request.go
+++ b/pkg/api/cloud/image/version/request.go
@@ -1,0 +1,30 @@
+package version
+
+type (
+	// ListAllRequest lists versions of a custom image. ImageID is the
+	// numeric id of the image (from cloud/image/get's "id" field, or
+	// list_all). Filters are optional pagination/ordering knobs.
+	ListAllRequest struct {
+		ImageID    int
+		SortBy     string
+		SortDir    string
+		PageSize   int
+		PageNumber int
+	}
+
+	// GetBuildRequest fetches the build log for a specific build.
+	// BuildID is the numeric build ID (Version.BuildID from
+	// ListAllResponse).
+	GetBuildRequest struct {
+		Code    string
+		BuildID string
+	}
+
+	// DeleteRequest removes a specific version of a custom image.
+	// Version is the version string (e.g. "1.1-1076"), available
+	// from ListAllResponse.
+	DeleteRequest struct {
+		Code    string
+		Version string
+	}
+)

--- a/pkg/api/cloud/image/version/response.go
+++ b/pkg/api/cloud/image/version/response.go
@@ -1,0 +1,38 @@
+package version
+
+import "github.com/sitehostnz/gosh/pkg/models"
+
+type (
+	// ListAllResponse is the return from
+	// /cloud/image/version/list_all.json.
+	ListAllResponse struct {
+		Return struct {
+			models.Pagination
+			Versions []Version `json:"data"`
+		} `json:"return"`
+		models.APIResponse
+	}
+
+	// Build is the body of GetBuildResponse — status plus the raw
+	// CI build trace.
+	Build struct {
+		BuildStatus string `json:"build_status"`
+		BuildTrace  string `json:"build_trace"`
+	}
+
+	// GetBuildResponse is the return from
+	// /cloud/image/version/get_build.json.
+	GetBuildResponse struct {
+		Return Build `json:"return"`
+		models.APIResponse
+	}
+
+	// JobResponse wraps the scheduler-job return for write
+	// operations on this namespace (currently only Delete).
+	JobResponse struct {
+		Return struct {
+			models.Job `json:"job"`
+		} `json:"return"`
+		models.APIResponse
+	}
+)

--- a/pkg/api/cloud/image/version/version_test.go
+++ b/pkg/api/cloud/image/version/version_test.go
@@ -1,0 +1,121 @@
+package version
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func readForm(t *testing.T, r *http.Request) url.Values {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	v, err := url.ParseQuery(string(body))
+	if err != nil {
+		t.Fatalf("parse body: %v", err)
+	}
+	return v
+}
+
+func TestListAll_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/image/version/list_all.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("image_id") != "77" {
+			t.Errorf("image_id = %q", r.URL.Query().Get("image_id"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status":true,"msg":"Successful",
+			"return":{
+				"total_items":1,"current_items":1,"current_page":1,"total_pages":1,
+				"data":[{
+					"id":"6421","client_id":"1","image_id":"415","version":"1.1-1076",
+					"build_id":"1076","build_status":"success","code":"my-custom-image",
+					"container_count":0
+				}]
+			}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).ListAll(context.Background(), ListAllRequest{ImageID: 77})
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if len(got.Return.Versions) != 1 || got.Return.Versions[0].BuildStatus != "success" {
+		t.Errorf("Versions = %+v", got.Return.Versions)
+	}
+}
+
+func TestListAll_RequiresImageID(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	if _, err := New(c).ListAll(context.Background(), ListAllRequest{}); err == nil {
+		t.Fatal("expected error for missing ImageID")
+	}
+}
+
+func TestGetBuild_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/image/version/get_build.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("code") != "my-custom-image" || q.Get("build_id") != "11" {
+			t.Errorf("query = %v", q)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status":true,"msg":"Successful",
+			"return":{"build_status":"failed","build_trace":"<build log here>"}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).GetBuild(context.Background(),
+		GetBuildRequest{Code: "my-custom-image", BuildID: "11"})
+	if err != nil {
+		t.Fatalf("GetBuild: %v", err)
+	}
+	if got.Return.BuildStatus != "failed" || got.Return.BuildTrace == "" {
+		t.Errorf("Return = %+v", got.Return)
+	}
+}
+
+func TestDelete_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/image/version/delete.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := readForm(t, r)
+		if v.Get("code") != "my-custom-image" || v.Get("version") != "1.1-1076" {
+			t.Errorf("form = %v", v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status":true,"msg":"Successful",
+			"return":{"job":{"type":"scheduler","id":7319505}}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).Delete(context.Background(),
+		DeleteRequest{Code: "my-custom-image", Version: "1.1-1076"})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got.Return.ID != 7319505 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
+	}
+}

--- a/pkg/api/cloud/image/version/version_test.go
+++ b/pkg/api/cloud/image/version/version_test.go
@@ -25,6 +25,7 @@ func readForm(t *testing.T, r *http.Request) url.Values {
 }
 
 func TestListAll_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/image/version/list_all.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -58,6 +59,7 @@ func TestListAll_Success(t *testing.T) {
 }
 
 func TestListAll_RequiresImageID(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
 	if _, err := New(c).ListAll(context.Background(), ListAllRequest{}); err == nil {
 		t.Fatal("expected error for missing ImageID")
@@ -65,6 +67,7 @@ func TestListAll_RequiresImageID(t *testing.T) {
 }
 
 func TestGetBuild_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/image/version/get_build.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -93,6 +96,7 @@ func TestGetBuild_Success(t *testing.T) {
 }
 
 func TestDelete_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/image/version/delete.json" {
 			t.Errorf("path = %q", r.URL.Path)

--- a/pkg/api/cloud/image/waitforbuild.go
+++ b/pkg/api/cloud/image/waitforbuild.go
@@ -1,0 +1,79 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sitehostnz/gosh/pkg/api/cloud/image/version"
+)
+
+// BuildStatus values returned by the platform CI for a custom image
+// version. Compared as strings; not exhaustive — surface unknowns
+// to the caller verbatim.
+const (
+	BuildStatusSuccess = "success"
+	BuildStatusFailed  = "failed"
+	BuildStatusRunning = "running"
+)
+
+// WaitForBuild polls cloud/image/version/list_all for the named
+// image (by numeric image_id) until the most-recent version reports
+// a terminal build status (success or failed), or the timeout is
+// reached. interval controls poll cadence.
+//
+// Returns the terminating Version. If the build failed, the caller
+// should fetch the trace via cloud.image.version.GetBuild(code,
+// build_id) to surface the failure to the user.
+//
+// Why a helper: the API doesn't expose a build-watching endpoint,
+// so consumers always have to poll. Doing it consistently here also
+// protects against the platform's "Only the last successfully built
+// version is available to be deployed" rule — we always look at the
+// latest version, never an older success.
+func (s *Client) WaitForBuild(ctx context.Context, imageID int, timeout, interval time.Duration) (version.Version, error) {
+	if imageID == 0 {
+		return version.Version{}, fmt.Errorf("cloud.image.WaitForBuild: imageID is required")
+	}
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+
+	versionClient := version.New(s.client)
+	deadline := time.Now().Add(timeout)
+
+	for {
+		resp, err := versionClient.ListAll(ctx, version.ListAllRequest{
+			ImageID:  imageID,
+			SortBy:   "date_added",
+			SortDir:  "DESC",
+			PageSize: 1,
+		})
+		if err != nil {
+			return version.Version{}, fmt.Errorf("listing versions for image %d: %w", imageID, err)
+		}
+
+		if len(resp.Return.Versions) > 0 {
+			latest := resp.Return.Versions[0]
+			switch latest.BuildStatus {
+			case BuildStatusSuccess, BuildStatusFailed:
+				return latest, nil
+			}
+		}
+
+		if time.Now().After(deadline) {
+			latestStatus := "no versions yet"
+			if len(resp.Return.Versions) > 0 {
+				latestStatus = resp.Return.Versions[0].BuildStatus
+			}
+			return version.Version{}, fmt.Errorf("timed out after %s waiting for image %d build (last status: %s)",
+				timeout, imageID, latestStatus)
+		}
+
+		select {
+		case <-ctx.Done():
+			return version.Version{}, ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}

--- a/pkg/api/cloud/image/waitforbuild.go
+++ b/pkg/api/cloud/image/waitforbuild.go
@@ -31,6 +31,8 @@ const (
 // protects against the platform's "Only the last successfully built
 // version is available to be deployed" rule — we always look at the
 // latest version, never an older success.
+//
+//nolint:cyclop // poll-loop with terminal/timeout/cancel branches; further extraction hurts readability
 func (s *Client) WaitForBuild(ctx context.Context, imageID int, timeout, interval time.Duration) (version.Version, error) {
 	if imageID == 0 {
 		return version.Version{}, fmt.Errorf("cloud.image.WaitForBuild: imageID is required")
@@ -43,37 +45,45 @@ func (s *Client) WaitForBuild(ctx context.Context, imageID int, timeout, interva
 	deadline := time.Now().Add(timeout)
 
 	for {
-		resp, err := versionClient.ListAll(ctx, version.ListAllRequest{
-			ImageID:  imageID,
-			SortBy:   "date_added",
-			SortDir:  "DESC",
-			PageSize: 1,
-		})
+		latest, hasVersion, err := pollLatestVersion(ctx, versionClient, imageID)
 		if err != nil {
-			return version.Version{}, fmt.Errorf("listing versions for image %d: %w", imageID, err)
+			return version.Version{}, err
 		}
-
-		if len(resp.Return.Versions) > 0 {
-			latest := resp.Return.Versions[0]
-			switch latest.BuildStatus {
-			case BuildStatusSuccess, BuildStatusFailed:
-				return latest, nil
-			}
+		if hasVersion && (latest.BuildStatus == BuildStatusSuccess || latest.BuildStatus == BuildStatusFailed) {
+			return latest, nil
 		}
-
 		if time.Now().After(deadline) {
-			latestStatus := "no versions yet"
-			if len(resp.Return.Versions) > 0 {
-				latestStatus = resp.Return.Versions[0].BuildStatus
-			}
-			return version.Version{}, fmt.Errorf("timed out after %s waiting for image %d build (last status: %s)",
-				timeout, imageID, latestStatus)
+			return version.Version{}, deadlineErr(timeout, imageID, latest, hasVersion)
 		}
-
 		select {
 		case <-ctx.Done():
 			return version.Version{}, ctx.Err()
 		case <-time.After(interval):
 		}
 	}
+}
+
+func pollLatestVersion(ctx context.Context, vc *version.Client, imageID int) (version.Version, bool, error) {
+	resp, err := vc.ListAll(ctx, version.ListAllRequest{
+		ImageID:  imageID,
+		SortBy:   "date_added",
+		SortDir:  "DESC",
+		PageSize: 1,
+	})
+	if err != nil {
+		return version.Version{}, false, fmt.Errorf("listing versions for image %d: %w", imageID, err)
+	}
+	if len(resp.Return.Versions) == 0 {
+		return version.Version{}, false, nil
+	}
+	return resp.Return.Versions[0], true, nil
+}
+
+func deadlineErr(timeout time.Duration, imageID int, latest version.Version, hasVersion bool) error {
+	status := "no versions yet"
+	if hasVersion {
+		status = latest.BuildStatus
+	}
+	return fmt.Errorf("timed out after %s waiting for image %d build (last status: %s)",
+		timeout, imageID, status)
 }

--- a/pkg/api/cloud/server/cloud_server_config_test.go
+++ b/pkg/api/cloud/server/cloud_server_config_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/sitehostnz/gosh/pkg/api"
 )
 
+const testServerName = "ch-test"
+
 func readForm(t *testing.T, r *http.Request) url.Values {
 	t.Helper()
 	body, err := io.ReadAll(r.Body)
@@ -25,11 +27,12 @@ func readForm(t *testing.T, r *http.Request) url.Values {
 }
 
 func TestGetUpdateWindow_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/server/get_update_window.json" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
-		if got := r.URL.Query().Get("server_name"); got != "ch-test" {
+		if got := r.URL.Query().Get("server_name"); got != testServerName {
 			t.Errorf("server_name = %q", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -41,7 +44,7 @@ func TestGetUpdateWindow_Success(t *testing.T) {
 	defer srv.Close()
 
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
-	got, err := New(c).GetUpdateWindow(context.Background(), GetUpdateWindowRequest{ServerName: "ch-test"})
+	got, err := New(c).GetUpdateWindow(context.Background(), GetUpdateWindowRequest{ServerName: testServerName})
 	if err != nil {
 		t.Fatalf("GetUpdateWindow: %v", err)
 	}
@@ -56,12 +59,13 @@ const jobOK = `{
 }`
 
 func TestSetUpdateWindow_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/server/set_update_window.json" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		v := readForm(t, r)
-		if v.Get("server_name") != "ch-test" {
+		if v.Get("server_name") != testServerName {
 			t.Errorf("server_name = %q", v.Get("server_name"))
 		}
 		if v.Get("enabled") != "1" || v.Get("day_of_week") != "2" ||
@@ -75,7 +79,7 @@ func TestSetUpdateWindow_Success(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
 	got, err := New(c).SetUpdateWindow(context.Background(), SetUpdateWindowRequest{
-		ServerName: "ch-test", Enabled: 1, DayOfWeek: 2, HourOfDay: 4, MinuteOfHour: 30,
+		ServerName: testServerName, Enabled: 1, DayOfWeek: 2, HourOfDay: 4, MinuteOfHour: 30,
 	})
 	if err != nil {
 		t.Fatalf("SetUpdateWindow: %v", err)
@@ -86,12 +90,13 @@ func TestSetUpdateWindow_Success(t *testing.T) {
 }
 
 func TestUpdateMinimumTLSVersion_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/server/update_minimum_tls_version.json" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		v := readForm(t, r)
-		if v.Get("server_name") != "ch-test" {
+		if v.Get("server_name") != testServerName {
 			t.Errorf("server_name = %q", v.Get("server_name"))
 		}
 		if v.Get("minimum_tls_version") != "TLSv1.2" {
@@ -104,7 +109,7 @@ func TestUpdateMinimumTLSVersion_Success(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
 	got, err := New(c).UpdateMinimumTLSVersion(context.Background(), UpdateMinimumTLSVersionRequest{
-		ServerName: "ch-test", MinimumTLSVersion: "TLSv1.2",
+		ServerName: testServerName, MinimumTLSVersion: "TLSv1.2",
 	})
 	if err != nil {
 		t.Fatalf("UpdateMinimumTLSVersion: %v", err)

--- a/pkg/api/cloud/server/cloud_server_config_test.go
+++ b/pkg/api/cloud/server/cloud_server_config_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func readForm(t *testing.T, r *http.Request) url.Values {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	v, err := url.ParseQuery(string(body))
+	if err != nil {
+		t.Fatalf("parse body: %v", err)
+	}
+	return v
+}
+
+func TestGetUpdateWindow_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/server/get_update_window.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("server_name"); got != "ch-test" {
+			t.Errorf("server_name = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status":true, "msg":"Successful",
+			"return": {"enabled": true, "day_of_week": 1, "hour_of_day": 3, "minute_of_hour": 0}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).GetUpdateWindow(context.Background(), GetUpdateWindowRequest{ServerName: "ch-test"})
+	if err != nil {
+		t.Fatalf("GetUpdateWindow: %v", err)
+	}
+	if !got.Return.Enabled || got.Return.DayOfWeek != 1 || got.Return.HourOfDay != 3 {
+		t.Errorf("Return = %+v", got.Return)
+	}
+}
+
+const jobOK = `{
+	"status":true, "msg":"Successful",
+	"return": {"job": {"id": 12345, "type": "scheduler"}}
+}`
+
+func TestSetUpdateWindow_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/server/set_update_window.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := readForm(t, r)
+		if v.Get("server_name") != "ch-test" {
+			t.Errorf("server_name = %q", v.Get("server_name"))
+		}
+		if v.Get("enabled") != "1" || v.Get("day_of_week") != "2" ||
+			v.Get("hour_of_day") != "4" || v.Get("minute_of_hour") != "30" {
+			t.Errorf("form = %v", v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).SetUpdateWindow(context.Background(), SetUpdateWindowRequest{
+		ServerName: "ch-test", Enabled: 1, DayOfWeek: 2, HourOfDay: 4, MinuteOfHour: 30,
+	})
+	if err != nil {
+		t.Fatalf("SetUpdateWindow: %v", err)
+	}
+	if got.Return.ID != 12345 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
+	}
+}
+
+func TestUpdateMinimumTLSVersion_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/server/update_minimum_tls_version.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := readForm(t, r)
+		if v.Get("server_name") != "ch-test" {
+			t.Errorf("server_name = %q", v.Get("server_name"))
+		}
+		if v.Get("minimum_tls_version") != "TLSv1.2" {
+			t.Errorf("minimum_tls_version = %q (note 'TLSv1.x' format required)", v.Get("minimum_tls_version"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).UpdateMinimumTLSVersion(context.Background(), UpdateMinimumTLSVersionRequest{
+		ServerName: "ch-test", MinimumTLSVersion: "TLSv1.2",
+	})
+	if err != nil {
+		t.Fatalf("UpdateMinimumTLSVersion: %v", err)
+	}
+	if got.Return.ID != 12345 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
+	}
+}

--- a/pkg/api/cloud/server/getupdatewindow.go
+++ b/pkg/api/cloud/server/getupdatewindow.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"context"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// GetUpdateWindow reads the maintenance/patching window configuration
+// for the named CCS via "cloud/server/get_update_window.json".
+//
+// Note: this endpoint returns "This server is not managed by SiteHost"
+// for managed=0 servers — only managed CCSes have a configured window.
+func (s *Client) GetUpdateWindow(ctx context.Context, request GetUpdateWindowRequest) (response GetUpdateWindowResponse, err error) {
+	u := "cloud/server/get_update_window.json"
+	keys := []string{"apikey", "client_id", "server_name"}
+
+	req, err := s.client.NewRequest("GET", u, "")
+	if err != nil {
+		return response, err
+	}
+	v := req.URL.Query()
+	v.Add("server_name", request.ServerName)
+	req.URL.RawQuery = net.Encode(v, keys)
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/server/request.go
+++ b/pkg/api/cloud/server/request.go
@@ -1,0 +1,36 @@
+package server
+
+type (
+	// GetUpdateWindowRequest identifies the CCS whose update-window
+	// configuration to read.
+	GetUpdateWindowRequest struct {
+		ServerName string `url:"server_name"`
+	}
+
+	// SetUpdateWindowRequest configures the maintenance / patching
+	// window for a CCS. All fields are required by the API.
+	//
+	// DayOfWeek is 1–7 (1 = Monday); HourOfDay is 0–23;
+	// MinuteOfHour is 0–59. Enabled controls whether the window is
+	// active (false disables auto-maintenance).
+	SetUpdateWindowRequest struct {
+		ServerName   string `url:"server_name"`
+		Enabled      int    `url:"enabled"` // 0 or 1
+		DayOfWeek    int    `url:"day_of_week"`
+		HourOfDay    int    `url:"hour_of_day"`
+		MinuteOfHour int    `url:"minute_of_hour"`
+	}
+
+	// UpdateMinimumTLSVersionRequest sets the minimum TLS version
+	// the CCS's nginx-proxy will negotiate. The API accepts the
+	// "TLSv1.x" format (e.g. "TLSv1.1", "TLSv1.2", "TLSv1.3");
+	// values like "1.2" or "TLS_1_2" are rejected.
+	//
+	// Note: there's no corresponding read endpoint. Consumers must
+	// either track the value they set or observe via TLS handshake
+	// (see examples/probe-tls-default).
+	UpdateMinimumTLSVersionRequest struct {
+		ServerName        string `url:"server_name"`
+		MinimumTLSVersion string `url:"minimum_tls_version"`
+	}
+)

--- a/pkg/api/cloud/server/request.go
+++ b/pkg/api/cloud/server/request.go
@@ -27,8 +27,8 @@ type (
 	// values like "1.2" or "TLS_1_2" are rejected.
 	//
 	// Note: there's no corresponding read endpoint. Consumers must
-	// either track the value they set or observe via TLS handshake
-	// (see examples/probe-tls-default).
+	// either track the value they set or observe it via a TLS
+	// handshake against a service running on the CCS.
 	UpdateMinimumTLSVersionRequest struct {
 		ServerName        string `url:"server_name"`
 		MinimumTLSVersion string `url:"minimum_tls_version"`

--- a/pkg/api/cloud/server/response.go
+++ b/pkg/api/cloud/server/response.go
@@ -8,4 +8,33 @@ type (
 		CloudServers []models.CloudServer `json:"return"`
 		models.APIResponse
 	}
+
+	// UpdateWindow describes a CCS's maintenance/patching window
+	// configuration as returned by get_update_window. DayOfWeek
+	// is 1–7 (1 = Monday); HourOfDay is 0–23; MinuteOfHour is 0–59.
+	UpdateWindow struct {
+		Enabled      bool `json:"enabled"`
+		DayOfWeek    int  `json:"day_of_week"`
+		HourOfDay    int  `json:"hour_of_day"`
+		MinuteOfHour int  `json:"minute_of_hour"`
+	}
+
+	// GetUpdateWindowResponse is the response from
+	// cloud/server/get_update_window.json. Returns the current
+	// maintenance-window configuration.
+	GetUpdateWindowResponse struct {
+		Return UpdateWindow `json:"return"`
+		models.APIResponse
+	}
+
+	// JobResponse is the shared response shape for the asynchronous
+	// write operations: SetUpdateWindow, UpdateMinimumTLSVersion.
+	// Each queues a scheduler job; the job ID is returned for
+	// tracking.
+	JobResponse struct {
+		Return struct {
+			models.Job `json:"job"`
+		} `json:"return"`
+		models.APIResponse
+	}
 )

--- a/pkg/api/cloud/server/setupdatewindow.go
+++ b/pkg/api/cloud/server/setupdatewindow.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// SetUpdateWindow configures the maintenance/patching window for
+// the named CCS via "cloud/server/set_update_window.json". Returns
+// a scheduler job; SDK consumers should poll until state=Completed.
+//
+// All five fields (ServerName, Enabled, DayOfWeek, HourOfDay,
+// MinuteOfHour) are required — the API rejects with "Could not
+// find a default value for the parameter '<field>'" if any are
+// omitted.
+func (s *Client) SetUpdateWindow(ctx context.Context, request SetUpdateWindowRequest) (response JobResponse, err error) {
+	u := "cloud/server/set_update_window.json"
+	keys := []string{
+		"client_id",
+		"server_name",
+		"enabled",
+		"day_of_week",
+		"hour_of_day",
+		"minute_of_hour",
+	}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server_name", request.ServerName)
+	values.Add("enabled", strconv.Itoa(request.Enabled))
+	values.Add("day_of_week", strconv.Itoa(request.DayOfWeek))
+	values.Add("hour_of_day", strconv.Itoa(request.HourOfDay))
+	values.Add("minute_of_hour", strconv.Itoa(request.MinuteOfHour))
+
+	req, err := s.client.NewRequest("POST", u, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/server/updateminimumtlsversion.go
+++ b/pkg/api/cloud/server/updateminimumtlsversion.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// UpdateMinimumTLSVersion sets the minimum TLS version the named
+// CCS's nginx-proxy will negotiate via
+// "cloud/server/update_minimum_tls_version.json". Returns a
+// scheduler job.
+//
+// MinimumTLSVersion must be in the "TLSv1.x" format
+// (e.g. "TLSv1.1", "TLSv1.2", "TLSv1.3"); other formats like "1.2"
+// or "TLS_1_2" are rejected with "The minimum tls version is not
+// valid."
+//
+// **There's no corresponding read endpoint.** Once set, the value
+// is observable only via TLS handshake against a service running on
+// the CCS, or by tracking the value in your own state. See
+// examples/probe-tls-default for the handshake-observation
+// approach.
+//
+// **Affects all stacks on the CCS.** This is a server-wide setting
+// that controls TLS termination at nginx-proxy for every customer
+// site running on the CCS. Tightening from the platform default
+// (TLSv1.1) will reject older TLS clients across all customer sites.
+func (s *Client) UpdateMinimumTLSVersion(ctx context.Context, request UpdateMinimumTLSVersionRequest) (response JobResponse, err error) {
+	u := "cloud/server/update_minimum_tls_version.json"
+	keys := []string{"client_id", "server_name", "minimum_tls_version"}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server_name", request.ServerName)
+	values.Add("minimum_tls_version", request.MinimumTLSVersion)
+
+	req, err := s.client.NewRequest("POST", u, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/server/updateminimumtlsversion.go
+++ b/pkg/api/cloud/server/updateminimumtlsversion.go
@@ -19,9 +19,7 @@ import (
 //
 // **There's no corresponding read endpoint.** Once set, the value
 // is observable only via TLS handshake against a service running on
-// the CCS, or by tracking the value in your own state. See
-// examples/probe-tls-default for the handshake-observation
-// approach.
+// the CCS, or by tracking the value in your own state.
 //
 // **Affects all stacks on the CCS.** This is a server-wide setting
 // that controls TLS termination at nginx-proxy for every customer

--- a/pkg/api/cloud/ssh/user/delete.go
+++ b/pkg/api/cloud/ssh/user/delete.go
@@ -7,7 +7,22 @@ import (
 	"github.com/sitehostnz/gosh/pkg/net"
 )
 
-// Delete an existing SSH user.
+// Delete an existing SSH user via cloud/ssh/user/delete.json.
+//
+// **Two-phase delete required (validated live).** The first call
+// queues a job that clears the user's container scoping; the
+// second call queues a job that actually removes the user record.
+// Calling Delete only once leaves the user record present on the
+// CCS and `/cloud/ssh/user/list` keeps returning it.
+//
+// Calling Delete twice in quick succession is also wrong — the
+// API rejects the second call with
+// "Unable to remove SSH user, there is a job already running on
+// this user." Sleep ~10s between phases (or poll the first
+// phase's job to Completed) before issuing the second.
+//
+// See examples/build-a-site and examples/custom-image cleanup
+// loops for the canonical pattern.
 func (s *Client) Delete(ctx context.Context, request DeleteRequest) (response DeleteResponse, err error) {
 	uri := "cloud/ssh/user/delete.json"
 	keys := []string{

--- a/pkg/api/cloud/ssh/user/delete.go
+++ b/pkg/api/cloud/ssh/user/delete.go
@@ -20,9 +20,6 @@ import (
 // "Unable to remove SSH user, there is a job already running on
 // this user." Sleep ~10s between phases (or poll the first
 // phase's job to Completed) before issuing the second.
-//
-// See examples/build-a-site and examples/custom-image cleanup
-// loops for the canonical pattern.
 func (s *Client) Delete(ctx context.Context, request DeleteRequest) (response DeleteResponse, err error) {
 	uri := "cloud/ssh/user/delete.json"
 	keys := []string{

--- a/pkg/api/cloud/ssh/user/request.go
+++ b/pkg/api/cloud/ssh/user/request.go
@@ -14,7 +14,7 @@ type (
 		Containers     []string `url:"containers[],omitempty"`
 		SSHKeys        []string `url:"ssh_keys[],omitempty"`
 		ReadOnlyConfig bool     `url:"read_only_config,omitempty"`
-		Volumes        []string `url:"read_only_config,omitempty"`
+		Volumes        []string `url:"volumes[],omitempty"`
 	}
 
 	// DeleteRequest a request to delete the database.

--- a/pkg/api/cloud/stack/add.go
+++ b/pkg/api/cloud/stack/add.go
@@ -13,12 +13,14 @@ import (
 //
 // # Gotchas (validated live, May 2026)
 //
-//  1. **Label must be a valid FQDN.** Despite the field name, the
-//     API uses Label as the primary hostname for nginx-proxy
-//     routing — passing a free-text label is rejected with
-//     "Unable to add stack, the hostname is invalid." Use the
-//     same FQDN you intend to put in the compose body's
-//     VIRTUAL_HOST.
+//  1. **Compose body must set `nz.sitehost.container.label` to a
+//     valid FQDN** for any container with type=www or
+//     type=application. The API rejects with "Unable to add stack,
+//     the hostname is invalid." if this label's value isn't a
+//     hostname-shaped string. The Label parameter on AddRequest
+//     is *not* the field being validated here — the check is on
+//     the compose body, not the API param. Set the same FQDN on
+//     both for consistency.
 //
 //  2. **Stack Name must come from cloud.stack.GenerateName.**
 //     The API rejects custom-shaped names with the same generic
@@ -37,11 +39,7 @@ import (
 //     required exceeds the number of available images on this
 //     server." The read-side fields on cloud.server.List
 //     (images_used / images_remaining) don't reliably reflect
-//     the live cap; provision a fresh CCS or free a slot. See
-//     docs/api-issues/ccs-write-time-resource-gate.md.
-//
-// See examples/custom-image and examples/build-a-site for the
-// canonical working compose body shape.
+//     the live cap; provision a fresh CCS or free a slot.
 func (s *Client) Add(ctx context.Context, request AddRequest) (response AddResponse, err error) {
 	uri := "cloud/stack/add.json"
 	keys := []string{

--- a/pkg/api/cloud/stack/add.go
+++ b/pkg/api/cloud/stack/add.go
@@ -10,6 +10,38 @@ import (
 )
 
 // Add creates a new cloud stack.
+//
+// # Gotchas (validated live, May 2026)
+//
+//  1. **Label must be a valid FQDN.** Despite the field name, the
+//     API uses Label as the primary hostname for nginx-proxy
+//     routing — passing a free-text label is rejected with
+//     "Unable to add stack, the hostname is invalid." Use the
+//     same FQDN you intend to put in the compose body's
+//     VIRTUAL_HOST.
+//
+//  2. **Stack Name must come from cloud.stack.GenerateName.**
+//     The API rejects custom-shaped names with the same generic
+//     "hostname is invalid" message; only platform-generated
+//     "cc<hex>" names are accepted.
+//
+//  3. **Compose image references need an explicit version tag.**
+//     `image: registry-clients.sitehost.co.nz/g_<id>/<code>` is
+//     rejected with "There was no image version provided."; you
+//     must include the `:1.0-<build_id>` tag from
+//     cloud.image.version.list_all (or use the WaitForBuild
+//     helper which surfaces it).
+//
+//  4. **Per-CCS write-time resource gate.** When the target CCS
+//     is at capacity the API returns "the number of new images
+//     required exceeds the number of available images on this
+//     server." The read-side fields on cloud.server.List
+//     (images_used / images_remaining) don't reliably reflect
+//     the live cap; provision a fresh CCS or free a slot. See
+//     docs/api-issues/ccs-write-time-resource-gate.md.
+//
+// See examples/custom-image and examples/build-a-site for the
+// canonical working compose body shape.
 func (s *Client) Add(ctx context.Context, request AddRequest) (response AddResponse, err error) {
 	uri := "cloud/stack/add.json"
 	keys := []string{

--- a/pkg/api/cloud/stack/backup.go
+++ b/pkg/api/cloud/stack/backup.go
@@ -1,0 +1,30 @@
+package stack
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Backup creates a backup of a cloud stack via
+// "cloud/stack/backup.json". ServerName and Name are required.
+// Returns a scheduler job id; the backup is taken asynchronously.
+func (s *Client) Backup(ctx context.Context, request BackupRequest) (response JobResponse, err error) {
+	uri := "cloud/stack/backup.json"
+	keys := []string{"client_id", "server", "name"}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server", request.ServerName)
+	values.Add("name", request.Name)
+
+	req, err := s.client.NewRequest("POST", uri, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/stack/copy.go
+++ b/pkg/api/cloud/stack/copy.go
@@ -1,0 +1,42 @@
+package stack
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Copy duplicates an existing cloud stack onto a destination server
+// via "cloud/stack/copy.json". SourceServer, Name, DestinationServer,
+// and Label are required. The new stack inherits the source's
+// docker_compose; Label sets the new stack's label.
+//
+// SourceServer and DestinationServer may be the same when copying
+// within a single server. Returns a scheduler job id.
+func (s *Client) Copy(ctx context.Context, request CopyRequest) (response JobResponse, err error) {
+	uri := "cloud/stack/copy.json"
+	keys := []string{
+		"client_id",
+		"source_server",
+		"name",
+		"destination_server",
+		"label",
+	}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("source_server", request.SourceServer)
+	values.Add("name", request.Name)
+	values.Add("destination_server", request.DestinationServer)
+	values.Add("label", request.Label)
+
+	req, err := s.client.NewRequest("POST", uri, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/stack/delete.go
+++ b/pkg/api/cloud/stack/delete.go
@@ -1,0 +1,33 @@
+package stack
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Delete removes a cloud stack via "cloud/stack/delete.json". Both
+// ServerName and Name are required. Returns a scheduler job id; the
+// operation is asynchronous.
+//
+// Destructive: removes the stack and its configuration. The
+// containers themselves are stopped and removed as part of the job.
+func (s *Client) Delete(ctx context.Context, request DeleteRequest) (response JobResponse, err error) {
+	uri := "cloud/stack/delete.json"
+	keys := []string{"client_id", "server", "name"}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server", request.ServerName)
+	values.Add("name", request.Name)
+
+	req, err := s.client.NewRequest("POST", uri, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/stack/overwrite.go
+++ b/pkg/api/cloud/stack/overwrite.go
@@ -1,0 +1,43 @@
+package stack
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Overwrite replaces a destination stack's contents with a source
+// stack's via "cloud/stack/overwrite.json". SourceServer, Name (the
+// source stack), DestinationServer, and DestinationStack are all
+// required.
+//
+// Destructive on the destination: the destination stack's
+// docker_compose is replaced with the source's. Returns a scheduler
+// job id.
+func (s *Client) Overwrite(ctx context.Context, request OverwriteRequest) (response JobResponse, err error) {
+	uri := "cloud/stack/overwrite.json"
+	keys := []string{
+		"client_id",
+		"source_server",
+		"name",
+		"destination_server",
+		"destination_stack",
+	}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("source_server", request.SourceServer)
+	values.Add("name", request.Name)
+	values.Add("destination_server", request.DestinationServer)
+	values.Add("destination_stack", request.DestinationStack)
+
+	req, err := s.client.NewRequest("POST", uri, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/stack/purgecache.go
+++ b/pkg/api/cloud/stack/purgecache.go
@@ -1,0 +1,33 @@
+package stack
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// PurgeCache clears cached content from a cloud stack via
+// "cloud/stack/purge_cache.json". ServerName and Name are required.
+// Returns a scheduler job id.
+//
+// Non-destructive: only the stack's edge cache is cleared; the
+// stack itself, its configuration, and its data are untouched.
+func (s *Client) PurgeCache(ctx context.Context, request PurgeCacheRequest) (response JobResponse, err error) {
+	uri := "cloud/stack/purge_cache.json"
+	keys := []string{"client_id", "server", "name"}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server", request.ServerName)
+	values.Add("name", request.Name)
+
+	req, err := s.client.NewRequest("POST", uri, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/stack/request.go
+++ b/pkg/api/cloud/stack/request.go
@@ -30,4 +30,63 @@ type (
 		Name       string   `json:"name"`
 		Containers []string `json:"containers"`
 	}
+
+	// UpdateRequest modifies an existing stack. ServerName and
+	// Name are required (they identify the stack). Label,
+	// DockerCompose, and EnvironmentVariables are sent when
+	// non-empty; leave them at their zero value to skip updating
+	// that property. EnableSSL is always sent (0 or 1).
+	UpdateRequest struct {
+		ServerName           string `json:"server_name"`
+		Name                 string `json:"name"`
+		Label                string `json:"label"`
+		EnableSSL            int    `json:"enable_ssl"`
+		DockerCompose        string `json:"docker_compose"`
+		EnvironmentVariables []models.EnvironmentVariable
+	}
+
+	// DeleteRequest removes an existing stack. Both fields are
+	// required.
+	DeleteRequest struct {
+		ServerName string `json:"server_name"`
+		Name       string `json:"name"`
+	}
+
+	// CopyRequest duplicates a stack onto a destination server.
+	// All four fields are required. SourceServer and
+	// DestinationServer may be the same when copying within a
+	// single server. Label is the new stack's label; the new
+	// stack's name is the same as the source's (the API does not
+	// expose a destination-name override on copy).
+	CopyRequest struct {
+		SourceServer      string `json:"source_server"`
+		Name              string `json:"name"`
+		DestinationServer string `json:"destination_server"`
+		Label             string `json:"label"`
+	}
+
+	// OverwriteRequest replaces a destination stack's contents
+	// with a source stack's. All four fields are required.
+	// DestinationStack identifies the existing target by name on
+	// DestinationServer; SourceServer + Name identify the source.
+	OverwriteRequest struct {
+		SourceServer      string `json:"source_server"`
+		Name              string `json:"name"`
+		DestinationServer string `json:"destination_server"`
+		DestinationStack  string `json:"destination_stack"`
+	}
+
+	// BackupRequest creates a backup of a stack. Both fields are
+	// required.
+	BackupRequest struct {
+		ServerName string `json:"server_name"`
+		Name       string `json:"name"`
+	}
+
+	// PurgeCacheRequest clears cached content from a stack. Both
+	// fields are required.
+	PurgeCacheRequest struct {
+		ServerName string `json:"server_name"`
+		Name       string `json:"name"`
+	}
 )

--- a/pkg/api/cloud/stack/response.go
+++ b/pkg/api/cloud/stack/response.go
@@ -43,4 +43,15 @@ type (
 		} `json:"return"`
 		models.APIResponse
 	}
+
+	// JobResponse is the shared response shape for the
+	// asynchronous write operations: Update, Delete, Copy,
+	// Overwrite, Backup, and PurgeCache. Each queues a scheduler
+	// job; the job id is returned for tracking.
+	JobResponse struct {
+		Return struct {
+			models.Job `json:"job"`
+		} `json:"return"`
+		models.APIResponse
+	}
 )

--- a/pkg/api/cloud/stack/ssl/letsencrypt/create.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/create.go
@@ -1,0 +1,34 @@
+package letsencrypt
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Create queues a Let's Encrypt cert issuance for the named stack.
+// The HTTP-01 challenge runs against the stack's vhost via
+// nginx-proxy; the stack must be reachable on port 80 at its label
+// hostname for the challenge to succeed.
+//
+// Returns a scheduler job; consumers must poll job.Get until
+// state="Completed" before assuming the cert is issued.
+func (s *Client) Create(ctx context.Context, request CreateRequest) (response JobResponse, err error) {
+	uri := "cloud/stack/ssl/lets_encrypt/create.json"
+	keys := []string{"client_id", "server", "name"}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server", request.ServerName)
+	values.Add("name", request.Name)
+
+	req, err := s.client.NewRequest("POST", uri, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/stack/ssl/letsencrypt/delete.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/delete.go
@@ -1,0 +1,31 @@
+package letsencrypt
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Delete removes the Let's Encrypt cert for the named stack.
+// Distinct from Revoke (which is a CA-side action invalidating the
+// cert across the public PKI); Delete only removes the cert from
+// the stack's nginx-proxy config. Returns a scheduler job.
+func (s *Client) Delete(ctx context.Context, request DeleteRequest) (response JobResponse, err error) {
+	uri := "cloud/stack/ssl/lets_encrypt/delete.json"
+	keys := []string{"client_id", "server", "name"}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server", request.ServerName)
+	values.Add("name", request.Name)
+
+	req, err := s.client.NewRequest("POST", uri, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/stack/ssl/letsencrypt/doc.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/doc.go
@@ -1,0 +1,20 @@
+// Package letsencrypt wraps SiteHost's Cloud-Container Let's Encrypt
+// endpoints under /cloud/stack/ssl/lets_encrypt. The companion
+// service running alongside the shared nginx-proxy on each Cloud
+// Container Server provisions certs via the HTTP-01 challenge: as
+// long as the stack's hostname (its label / VIRTUAL_HOST env) is
+// reachable on port 80, a cert request will succeed.
+//
+// Endpoints exposed today:
+//
+//   - List   → cloud/stack/ssl/lets_encrypt/list_all.json   (read)
+//   - Create → cloud/stack/ssl/lets_encrypt/create.json     (write, async)
+//   - Delete → cloud/stack/ssl/lets_encrypt/delete.json     (write, async)
+//   - Renew  → cloud/stack/ssl/lets_encrypt/renew.json      (write, async)
+//   - Revoke → cloud/stack/ssl/lets_encrypt/revoke.json     (write, async)
+//
+// All four write operations return a scheduler job; consumers must
+// poll job.Get until state="Completed" before issuing dependent
+// calls — see the JobResponse type and the package-level convention
+// notes on `pkg/api/cloud/stack`.
+package letsencrypt

--- a/pkg/api/cloud/stack/ssl/letsencrypt/letsencrypt_test.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/letsencrypt_test.go
@@ -41,6 +41,9 @@ func TestList_Success(t *testing.T) {
 		if got := r.URL.Query().Get("server"); got != "ch-test" {
 			t.Errorf("server = %q (note: not server_name)", got)
 		}
+		if got := r.URL.Query().Get("name"); got != "my-stack" {
+			t.Errorf("name = %q, want my-stack (StackName is required)", got)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
 			"status": true, "msg": "Successful.",
@@ -59,7 +62,10 @@ func TestList_Success(t *testing.T) {
 	defer server.Close()
 
 	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
-	got, err := New(c).List(context.Background(), ListRequest{ServerName: "ch-test"})
+	got, err := New(c).List(context.Background(), ListRequest{
+		ServerName: "ch-test",
+		StackName:  "my-stack",
+	})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}

--- a/pkg/api/cloud/stack/ssl/letsencrypt/letsencrypt_test.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/letsencrypt_test.go
@@ -1,0 +1,138 @@
+package letsencrypt
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+const jobOK = `{
+	"status": true, "msg": "Successful.",
+	"return": {"job": {"id": 12345, "type": "scheduler"}}
+}`
+
+func readForm(t *testing.T, r *http.Request) url.Values {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	v, err := url.ParseQuery(string(body))
+	if err != nil {
+		t.Fatalf("parse body: %v", err)
+	}
+	return v
+}
+
+func TestList_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/stack/ssl/lets_encrypt/list_all.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if r.Method != "GET" {
+			t.Errorf("method = %q", r.Method)
+		}
+		if got := r.URL.Query().Get("server"); got != "ch-test" {
+			t.Errorf("server = %q (note: not server_name)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true, "msg": "Successful.",
+			"return": {
+				"cc1234": {
+					"issuer": "E8",
+					"not_before": "2026-01-01 00:00:00",
+					"not_after":  "2026-04-01 00:00:00",
+					"serial":     "1234567890",
+					"expired":    "0",
+					"is_missing": "0"
+				}
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).List(context.Background(), ListRequest{ServerName: "ch-test"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got.Return) != 1 {
+		t.Fatalf("len(Return) = %d", len(got.Return))
+	}
+	cert, ok := got.Return["cc1234"]
+	if !ok {
+		t.Fatalf("Return missing cc1234 key")
+	}
+	if cert.Issuer != "E8" {
+		t.Errorf("Issuer = %q", cert.Issuer)
+	}
+	if cert.Expired != "0" {
+		t.Errorf("Expired = %q (string-typed bool)", cert.Expired)
+	}
+}
+
+func assertWriteSends(t *testing.T, path, server, name string, fn func(*Client) error) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != path {
+			t.Errorf("path = %q, want %q", r.URL.Path, path)
+		}
+		if r.Method != "POST" {
+			t.Errorf("method = %q", r.Method)
+		}
+		v := readForm(t, r)
+		if v.Get("server") != server {
+			t.Errorf("server = %q", v.Get("server"))
+		}
+		if v.Get("name") != name {
+			t.Errorf("name = %q", v.Get("name"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	}))
+	defer srv.Close()
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if err := fn(New(c)); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+}
+
+func TestCreate_Success(t *testing.T) {
+	assertWriteSends(t, "/cloud/stack/ssl/lets_encrypt/create.json", "ch-test", "cc1234", func(c *Client) error {
+		got, err := c.Create(context.Background(), CreateRequest{ServerName: "ch-test", Name: "cc1234"})
+		if err != nil {
+			return err
+		}
+		if got.Return.ID != 12345 {
+			t.Errorf("Job.ID = %d", got.Return.ID)
+		}
+		return nil
+	})
+}
+
+func TestDelete_Success(t *testing.T) {
+	assertWriteSends(t, "/cloud/stack/ssl/lets_encrypt/delete.json", "ch-test", "cc1234", func(c *Client) error {
+		_, err := c.Delete(context.Background(), DeleteRequest{ServerName: "ch-test", Name: "cc1234"})
+		return err
+	})
+}
+
+func TestRenew_Success(t *testing.T) {
+	assertWriteSends(t, "/cloud/stack/ssl/lets_encrypt/renew.json", "ch-test", "cc1234", func(c *Client) error {
+		_, err := c.Renew(context.Background(), RenewRequest{ServerName: "ch-test", Name: "cc1234"})
+		return err
+	})
+}
+
+func TestRevoke_Success(t *testing.T) {
+	assertWriteSends(t, "/cloud/stack/ssl/lets_encrypt/revoke.json", "ch-test", "cc1234", func(c *Client) error {
+		_, err := c.Revoke(context.Background(), RevokeRequest{ServerName: "ch-test", Name: "cc1234"})
+		return err
+	})
+}

--- a/pkg/api/cloud/stack/ssl/letsencrypt/letsencrypt_test.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/letsencrypt_test.go
@@ -30,6 +30,7 @@ func readForm(t *testing.T, r *http.Request) url.Values {
 }
 
 func TestList_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/stack/ssl/lets_encrypt/list_all.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -77,8 +78,13 @@ func TestList_Success(t *testing.T) {
 	}
 }
 
-func assertWriteSends(t *testing.T, path, server, name string, fn func(*Client) error) {
+// assertWriteSends spins up a httptest server for one of the
+// letsencrypt write endpoints, asserts the path + form fields,
+// and runs fn against it. server is fixed at "ch-test" for the
+// fixture suite.
+func assertWriteSends(t *testing.T, path string, fn func(*Client) error) {
 	t.Helper()
+	const wantServer = "ch-test"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != path {
 			t.Errorf("path = %q, want %q", r.URL.Path, path)
@@ -87,11 +93,11 @@ func assertWriteSends(t *testing.T, path, server, name string, fn func(*Client) 
 			t.Errorf("method = %q", r.Method)
 		}
 		v := readForm(t, r)
-		if v.Get("server") != server {
+		if v.Get("server") != wantServer {
 			t.Errorf("server = %q", v.Get("server"))
 		}
-		if v.Get("name") != name {
-			t.Errorf("name = %q", v.Get("name"))
+		if v.Get("name") != "cc1234" {
+			t.Errorf("name = %q (want cc1234)", v.Get("name"))
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, jobOK)
@@ -104,7 +110,8 @@ func assertWriteSends(t *testing.T, path, server, name string, fn func(*Client) 
 }
 
 func TestCreate_Success(t *testing.T) {
-	assertWriteSends(t, "/cloud/stack/ssl/lets_encrypt/create.json", "ch-test", "cc1234", func(c *Client) error {
+	t.Parallel()
+	assertWriteSends(t, "/cloud/stack/ssl/lets_encrypt/create.json", func(c *Client) error {
 		got, err := c.Create(context.Background(), CreateRequest{ServerName: "ch-test", Name: "cc1234"})
 		if err != nil {
 			return err
@@ -117,21 +124,24 @@ func TestCreate_Success(t *testing.T) {
 }
 
 func TestDelete_Success(t *testing.T) {
-	assertWriteSends(t, "/cloud/stack/ssl/lets_encrypt/delete.json", "ch-test", "cc1234", func(c *Client) error {
+	t.Parallel()
+	assertWriteSends(t, "/cloud/stack/ssl/lets_encrypt/delete.json", func(c *Client) error {
 		_, err := c.Delete(context.Background(), DeleteRequest{ServerName: "ch-test", Name: "cc1234"})
 		return err
 	})
 }
 
 func TestRenew_Success(t *testing.T) {
-	assertWriteSends(t, "/cloud/stack/ssl/lets_encrypt/renew.json", "ch-test", "cc1234", func(c *Client) error {
+	t.Parallel()
+	assertWriteSends(t, "/cloud/stack/ssl/lets_encrypt/renew.json", func(c *Client) error {
 		_, err := c.Renew(context.Background(), RenewRequest{ServerName: "ch-test", Name: "cc1234"})
 		return err
 	})
 }
 
 func TestRevoke_Success(t *testing.T) {
-	assertWriteSends(t, "/cloud/stack/ssl/lets_encrypt/revoke.json", "ch-test", "cc1234", func(c *Client) error {
+	t.Parallel()
+	assertWriteSends(t, "/cloud/stack/ssl/lets_encrypt/revoke.json", func(c *Client) error {
 		_, err := c.Revoke(context.Background(), RevokeRequest{ServerName: "ch-test", Name: "cc1234"})
 		return err
 	})

--- a/pkg/api/cloud/stack/ssl/letsencrypt/list.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/list.go
@@ -1,0 +1,31 @@
+package letsencrypt
+
+import (
+	"context"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// List retrieves the LE certificates currently provisioned across
+// the stacks on the given Cloud Container Server. Returns a map
+// keyed by stack name. Stacks without an LE cert are absent from
+// the map.
+func (s *Client) List(ctx context.Context, request ListRequest) (response ListResponse, err error) {
+	uri := "cloud/stack/ssl/lets_encrypt/list_all.json"
+	keys := []string{"apikey", "client_id", "server"}
+
+	req, err := s.client.NewRequest("GET", uri, "")
+	if err != nil {
+		return response, err
+	}
+
+	v := req.URL.Query()
+	v.Add("server", request.ServerName)
+	req.URL.RawQuery = net.Encode(v, keys)
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+

--- a/pkg/api/cloud/stack/ssl/letsencrypt/list.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/list.go
@@ -28,4 +28,3 @@ func (s *Client) List(ctx context.Context, request ListRequest) (response ListRe
 	}
 	return response, nil
 }
-

--- a/pkg/api/cloud/stack/ssl/letsencrypt/list.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/list.go
@@ -6,13 +6,14 @@ import (
 	"github.com/sitehostnz/gosh/pkg/net"
 )
 
-// List retrieves the LE certificates currently provisioned across
-// the stacks on the given Cloud Container Server. Returns a map
-// keyed by stack name. Stacks without an LE cert are absent from
-// the map.
+// List retrieves the LE certificates currently provisioned for the
+// named stack on a Cloud Container Server. Returns a map keyed by
+// container name within that stack; containers without an LE cert
+// are absent from the map. Containers (optional) restricts the
+// result to specific containers.
 func (s *Client) List(ctx context.Context, request ListRequest) (response ListResponse, err error) {
 	uri := "cloud/stack/ssl/lets_encrypt/list_all.json"
-	keys := []string{"apikey", "client_id", "server"}
+	keys := []string{"apikey", "client_id", "server", "name", "containers"}
 
 	req, err := s.client.NewRequest("GET", uri, "")
 	if err != nil {
@@ -21,6 +22,10 @@ func (s *Client) List(ctx context.Context, request ListRequest) (response ListRe
 
 	v := req.URL.Query()
 	v.Add("server", request.ServerName)
+	v.Add("name", request.StackName)
+	for _, container := range request.Containers {
+		v.Add("containers", container)
+	}
 	req.URL.RawQuery = net.Encode(v, keys)
 
 	if err := s.client.Do(ctx, req, &response); err != nil {

--- a/pkg/api/cloud/stack/ssl/letsencrypt/models.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/models.go
@@ -1,0 +1,18 @@
+package letsencrypt
+
+import (
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+type (
+	// Client is a Service for Cloud Container Let's Encrypt
+	// management.
+	Client struct {
+		client *api.Client
+	}
+)
+
+// New is an initialisation function.
+func New(c *api.Client) *Client {
+	return &Client{client: c}
+}

--- a/pkg/api/cloud/stack/ssl/letsencrypt/renew.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/renew.go
@@ -1,0 +1,31 @@
+package letsencrypt
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Renew forces an early renewal of the LE cert for the named stack.
+// The companion auto-renews on schedule (typically when the cert
+// has < 30 days remaining); use Renew only for out-of-band refresh.
+// Returns a scheduler job.
+func (s *Client) Renew(ctx context.Context, request RenewRequest) (response JobResponse, err error) {
+	uri := "cloud/stack/ssl/lets_encrypt/renew.json"
+	keys := []string{"client_id", "server", "name"}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server", request.ServerName)
+	values.Add("name", request.Name)
+
+	req, err := s.client.NewRequest("POST", uri, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/stack/ssl/letsencrypt/request.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/request.go
@@ -8,8 +8,9 @@ type (
 	// is an optional filter restricting the result to specific
 	// containers within the stack.
 	//
-	// Both ServerName and StackName are required by the API; omitting
-	// the stack name returns "The stack name is missing."
+	// Both ServerName and StackName are required by the API;
+	// omitting the stack name returns the API error
+	// "The stack name is missing.".
 	ListRequest struct {
 		ServerName string   `url:"server"`
 		StackName  string   `url:"name"`

--- a/pkg/api/cloud/stack/ssl/letsencrypt/request.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/request.go
@@ -1,11 +1,19 @@
 package letsencrypt
 
 type (
-	// ListRequest identifies the cloud server whose stacks' LE certs
-	// to enumerate. ServerName is the CCS name (the unprefixed
+	// ListRequest identifies a stack on a CCS whose Let's Encrypt
+	// certs to list. ServerName is the CCS name (the unprefixed
 	// "server" parameter that cloud/stack/* uses, not "server_name").
+	// StackName is the stack's name within that server. Containers
+	// is an optional filter restricting the result to specific
+	// containers within the stack.
+	//
+	// Both ServerName and StackName are required by the API; omitting
+	// the stack name returns "The stack name is missing."
 	ListRequest struct {
-		ServerName string `url:"server"`
+		ServerName string   `url:"server"`
+		StackName  string   `url:"name"`
+		Containers []string `url:"containers,omitempty"`
 	}
 
 	// CreateRequest queues an LE-cert issuance for the named stack.

--- a/pkg/api/cloud/stack/ssl/letsencrypt/request.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/request.go
@@ -1,0 +1,41 @@
+package letsencrypt
+
+type (
+	// ListRequest identifies the cloud server whose stacks' LE certs
+	// to enumerate. ServerName is the CCS name (the unprefixed
+	// "server" parameter that cloud/stack/* uses, not "server_name").
+	ListRequest struct {
+		ServerName string `url:"server"`
+	}
+
+	// CreateRequest queues an LE-cert issuance for the named stack.
+	// HTTP-01 validation runs against the stack's nginx-proxy
+	// vhost; the stack must be reachable on port 80 at its label
+	// hostname for the challenge to succeed.
+	CreateRequest struct {
+		ServerName string `url:"server"`
+		Name       string `url:"name"`
+	}
+
+	// DeleteRequest removes the LE cert for the named stack.
+	DeleteRequest struct {
+		ServerName string `url:"server"`
+		Name       string `url:"name"`
+	}
+
+	// RenewRequest forces an early renewal of the LE cert for the
+	// named stack. Normally the companion auto-renews on schedule;
+	// use this for out-of-band refresh.
+	RenewRequest struct {
+		ServerName string `url:"server"`
+		Name       string `url:"name"`
+	}
+
+	// RevokeRequest revokes the LE cert for the named stack at the
+	// CA. Distinct from Delete: revocation is a CA-side action that
+	// invalidates the cert across the public PKI.
+	RevokeRequest struct {
+		ServerName string `url:"server"`
+		Name       string `url:"name"`
+	}
+)

--- a/pkg/api/cloud/stack/ssl/letsencrypt/response.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/response.go
@@ -1,0 +1,39 @@
+package letsencrypt
+
+import "github.com/sitehostnz/gosh/pkg/models"
+
+type (
+	// CertInfo is a single LE cert's metadata as returned by
+	// list_all. Per-stack info is keyed by the stack name in the
+	// outer Return map of ListResponse.
+	//
+	// String-typed boolean fields (Expired, IsMissing) reflect the
+	// API's actual response — values arrive as strings ("0"/"1")
+	// rather than typed bools.
+	CertInfo struct {
+		Issuer    string `json:"issuer"`
+		NotBefore string `json:"not_before"`
+		NotAfter  string `json:"not_after"`
+		Serial    string `json:"serial"`
+		Expired   string `json:"expired"`
+		IsMissing string `json:"is_missing"`
+	}
+
+	// ListResponse represents the response from list_all. Return is
+	// a map keyed by stack name to that stack's cert metadata. A
+	// stack with no LE cert simply doesn't appear in the map.
+	ListResponse struct {
+		Return map[string]CertInfo `json:"return"`
+		models.APIResponse
+	}
+
+	// JobResponse is the shared response shape for the asynchronous
+	// write operations: Create, Delete, Renew, Revoke. Each queues
+	// a scheduler job; the job id is returned for tracking.
+	JobResponse struct {
+		Return struct {
+			models.Job `json:"job"`
+		} `json:"return"`
+		models.APIResponse
+	}
+)

--- a/pkg/api/cloud/stack/ssl/letsencrypt/response.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/response.go
@@ -8,8 +8,8 @@ import (
 
 type (
 	// CertInfo is a single LE cert's metadata as returned by
-	// list_all. Per-stack info is keyed by the stack name in the
-	// outer Return map of ListResponse.
+	// list_all. Per-container info is keyed by container name in
+	// the outer Return map of ListResponse.
 	//
 	// String-typed boolean fields (Expired, IsMissing) reflect the
 	// API's actual response — values arrive as strings ("0"/"1")
@@ -24,8 +24,9 @@ type (
 	}
 
 	// ListResponse represents the response from list_all. Return is
-	// a map keyed by stack name to that stack's cert metadata. A
-	// stack with no LE cert simply doesn't appear in the map.
+	// a map keyed by container name (within the queried stack) to
+	// that container's cert metadata. A container with no LE cert
+	// simply doesn't appear in the map.
 	ListResponse struct {
 		Return map[string]CertInfo `json:"return"`
 		models.APIResponse

--- a/pkg/api/cloud/stack/ssl/letsencrypt/response.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/response.go
@@ -1,6 +1,10 @@
 package letsencrypt
 
-import "github.com/sitehostnz/gosh/pkg/models"
+import (
+	"encoding/json"
+
+	"github.com/sitehostnz/gosh/pkg/models"
+)
 
 type (
 	// CertInfo is a single LE cert's metadata as returned by
@@ -37,3 +41,22 @@ type (
 		models.APIResponse
 	}
 )
+
+// UnmarshalJSON tolerates the empty-array form the API returns when
+// no stacks have LE certs configured.
+func (r *ListResponse) UnmarshalJSON(data []byte) error {
+	var envelope struct {
+		Return json.RawMessage `json:"return"`
+		models.APIResponse
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return err
+	}
+	r.APIResponse = envelope.APIResponse
+	raw := envelope.Return
+	if len(raw) == 0 || string(raw) == "null" || string(raw) == "[]" {
+		r.Return = map[string]CertInfo{}
+		return nil
+	}
+	return json.Unmarshal(raw, &r.Return)
+}

--- a/pkg/api/cloud/stack/ssl/letsencrypt/revoke.go
+++ b/pkg/api/cloud/stack/ssl/letsencrypt/revoke.go
@@ -1,0 +1,32 @@
+package letsencrypt
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Revoke invalidates the LE cert for the named stack at the CA.
+// Distinct from Delete: revocation propagates across the public PKI
+// and means the cert can never be reinstated — issue a new one if
+// you need HTTPS to keep working. Use Delete to remove the cert
+// from local config without revoking. Returns a scheduler job.
+func (s *Client) Revoke(ctx context.Context, request RevokeRequest) (response JobResponse, err error) {
+	uri := "cloud/stack/ssl/lets_encrypt/revoke.json"
+	keys := []string{"client_id", "server", "name"}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server", request.ServerName)
+	values.Add("name", request.Name)
+
+	req, err := s.client.NewRequest("POST", uri, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/stack/update.go
+++ b/pkg/api/cloud/stack/update.go
@@ -1,0 +1,59 @@
+package stack
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Update modifies an existing cloud stack via "cloud/stack/update.json".
+// ServerName and Name are required. Label, EnableSSL, DockerCompose,
+// and EnvironmentVariables are sent when non-zero / non-empty; the
+// caller can leave any of them at zero to skip updating that field.
+//
+// Returns a scheduler job id; the operation is asynchronous.
+func (s *Client) Update(ctx context.Context, request UpdateRequest) (response JobResponse, err error) {
+	uri := "cloud/stack/update.json"
+	keys := []string{
+		"client_id",
+		"server",
+		"name",
+		"label",
+		"enable_ssl",
+		"docker_compose",
+	}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server", request.ServerName)
+	values.Add("name", request.Name)
+	if request.Label != "" {
+		values.Add("label", request.Label)
+	}
+	values.Add("enable_ssl", strconv.Itoa(request.EnableSSL))
+	if request.DockerCompose != "" {
+		values.Add("docker_compose", request.DockerCompose)
+	}
+
+	var vars string
+	for _, envVar := range request.EnvironmentVariables {
+		vars += fmt.Sprintf("  %s: %s\n", envVar.Name, envVar.Content)
+	}
+	if vars != "" {
+		key := "environments[" + request.Name + ".env]"
+		values.Add(key, fmt.Sprintf("vars: \n%s", vars))
+		keys = append(keys, key)
+	}
+
+	req, err := s.client.NewRequest("POST", uri, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/cloud/stack/writes_test.go
+++ b/pkg/api/cloud/stack/writes_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/sitehostnz/gosh/pkg/api"
 )
 
+const (
+	testServerName = "srv1"
+	testStackName  = "stack1"
+)
+
 // jobOK returns a stock JobResponse body for write-write tests.
 const jobOK = `{
 	"status": true, "msg": "Successful.",
@@ -33,6 +38,7 @@ func readForm(t *testing.T, r *http.Request) url.Values {
 }
 
 func TestUpdate_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/stack/update.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -41,10 +47,10 @@ func TestUpdate_Success(t *testing.T) {
 			t.Errorf("method = %q", r.Method)
 		}
 		v := readForm(t, r)
-		if v.Get("server") != "srv1" {
+		if v.Get("server") != testServerName {
 			t.Errorf("server = %q", v.Get("server"))
 		}
-		if v.Get("name") != "stack1" {
+		if v.Get("name") != testStackName {
 			t.Errorf("name = %q", v.Get("name"))
 		}
 		if v.Get("label") != "new-label" {
@@ -60,7 +66,7 @@ func TestUpdate_Success(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
 	got, err := New(c).Update(context.Background(), UpdateRequest{
-		ServerName: "srv1", Name: "stack1", Label: "new-label", EnableSSL: 1,
+		ServerName: testServerName, Name: testStackName, Label: "new-label", EnableSSL: 1,
 	})
 	if err != nil {
 		t.Fatalf("Update: %v", err)
@@ -71,12 +77,13 @@ func TestUpdate_Success(t *testing.T) {
 }
 
 func TestDelete_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/stack/delete.json" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		v := readForm(t, r)
-		if v.Get("server") != "srv1" || v.Get("name") != "stack1" {
+		if v.Get("server") != testServerName || v.Get("name") != testStackName {
 			t.Errorf("server=%q name=%q", v.Get("server"), v.Get("name"))
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -86,7 +93,7 @@ func TestDelete_Success(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
 	got, err := New(c).Delete(context.Background(), DeleteRequest{
-		ServerName: "srv1", Name: "stack1",
+		ServerName: testServerName, Name: testStackName,
 	})
 	if err != nil {
 		t.Fatalf("Delete: %v", err)
@@ -97,15 +104,16 @@ func TestDelete_Success(t *testing.T) {
 }
 
 func TestCopy_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/stack/copy.json" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		v := readForm(t, r)
-		if v.Get("source_server") != "srv1" {
+		if v.Get("source_server") != testServerName {
 			t.Errorf("source_server = %q", v.Get("source_server"))
 		}
-		if v.Get("name") != "stack1" {
+		if v.Get("name") != testStackName {
 			t.Errorf("name = %q", v.Get("name"))
 		}
 		if v.Get("destination_server") != "srv2" {
@@ -121,7 +129,7 @@ func TestCopy_Success(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
 	got, err := New(c).Copy(context.Background(), CopyRequest{
-		SourceServer: "srv1", Name: "stack1",
+		SourceServer: testServerName, Name: testStackName,
 		DestinationServer: "srv2", Label: "copy-label",
 	})
 	if err != nil {
@@ -133,15 +141,16 @@ func TestCopy_Success(t *testing.T) {
 }
 
 func TestOverwrite_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/stack/overwrite.json" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		v := readForm(t, r)
-		if v.Get("source_server") != "srv1" {
+		if v.Get("source_server") != testServerName {
 			t.Errorf("source_server = %q", v.Get("source_server"))
 		}
-		if v.Get("name") != "stack1" {
+		if v.Get("name") != testStackName {
 			t.Errorf("name = %q", v.Get("name"))
 		}
 		if v.Get("destination_server") != "srv2" {
@@ -157,7 +166,7 @@ func TestOverwrite_Success(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
 	got, err := New(c).Overwrite(context.Background(), OverwriteRequest{
-		SourceServer: "srv1", Name: "stack1",
+		SourceServer: testServerName, Name: testStackName,
 		DestinationServer: "srv2", DestinationStack: "stack2",
 	})
 	if err != nil {
@@ -169,12 +178,13 @@ func TestOverwrite_Success(t *testing.T) {
 }
 
 func TestBackup_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/stack/backup.json" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		v := readForm(t, r)
-		if v.Get("server") != "srv1" || v.Get("name") != "stack1" {
+		if v.Get("server") != testServerName || v.Get("name") != testStackName {
 			t.Errorf("server=%q name=%q", v.Get("server"), v.Get("name"))
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -184,7 +194,7 @@ func TestBackup_Success(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
 	got, err := New(c).Backup(context.Background(), BackupRequest{
-		ServerName: "srv1", Name: "stack1",
+		ServerName: testServerName, Name: testStackName,
 	})
 	if err != nil {
 		t.Fatalf("Backup: %v", err)
@@ -195,12 +205,13 @@ func TestBackup_Success(t *testing.T) {
 }
 
 func TestPurgeCache_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/stack/purge_cache.json" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		v := readForm(t, r)
-		if v.Get("server") != "srv1" || v.Get("name") != "stack1" {
+		if v.Get("server") != testServerName || v.Get("name") != testStackName {
 			t.Errorf("server=%q name=%q", v.Get("server"), v.Get("name"))
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -210,7 +221,7 @@ func TestPurgeCache_Success(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
 	got, err := New(c).PurgeCache(context.Background(), PurgeCacheRequest{
-		ServerName: "srv1", Name: "stack1",
+		ServerName: testServerName, Name: testStackName,
 	})
 	if err != nil {
 		t.Fatalf("PurgeCache: %v", err)
@@ -221,14 +232,15 @@ func TestPurgeCache_Success(t *testing.T) {
 }
 
 func TestWrites_StatusFalse(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"status": false, "msg": "Stack not found"}`)
 	}))
 	defer server.Close()
 
 	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
-	_, err := New(c).Delete(context.Background(), DeleteRequest{ServerName: "srv1", Name: "missing"})
+	_, err := New(c).Delete(context.Background(), DeleteRequest{ServerName: testServerName, Name: "missing"})
 	if err == nil {
 		t.Fatal("expected error on status:false, got nil")
 	}

--- a/pkg/api/cloud/stack/writes_test.go
+++ b/pkg/api/cloud/stack/writes_test.go
@@ -1,0 +1,238 @@
+package stack
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+// jobOK returns a stock JobResponse body for write-write tests.
+const jobOK = `{
+	"status": true, "msg": "Successful.",
+	"return": {"job": {"id": 12345, "type": "scheduler"}}
+}`
+
+// readForm parses the POST body of a request as form values.
+func readForm(t *testing.T, r *http.Request) url.Values {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	v, err := url.ParseQuery(string(body))
+	if err != nil {
+		t.Fatalf("parse body: %v", err)
+	}
+	return v
+}
+
+func TestUpdate_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/stack/update.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if r.Method != "POST" {
+			t.Errorf("method = %q", r.Method)
+		}
+		v := readForm(t, r)
+		if v.Get("server") != "srv1" {
+			t.Errorf("server = %q", v.Get("server"))
+		}
+		if v.Get("name") != "stack1" {
+			t.Errorf("name = %q", v.Get("name"))
+		}
+		if v.Get("label") != "new-label" {
+			t.Errorf("label = %q", v.Get("label"))
+		}
+		if v.Get("enable_ssl") != "1" {
+			t.Errorf("enable_ssl = %q", v.Get("enable_ssl"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).Update(context.Background(), UpdateRequest{
+		ServerName: "srv1", Name: "stack1", Label: "new-label", EnableSSL: 1,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got.Return.ID != 12345 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
+	}
+}
+
+func TestDelete_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/stack/delete.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := readForm(t, r)
+		if v.Get("server") != "srv1" || v.Get("name") != "stack1" {
+			t.Errorf("server=%q name=%q", v.Get("server"), v.Get("name"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).Delete(context.Background(), DeleteRequest{
+		ServerName: "srv1", Name: "stack1",
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got.Return.ID != 12345 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
+	}
+}
+
+func TestCopy_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/stack/copy.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := readForm(t, r)
+		if v.Get("source_server") != "srv1" {
+			t.Errorf("source_server = %q", v.Get("source_server"))
+		}
+		if v.Get("name") != "stack1" {
+			t.Errorf("name = %q", v.Get("name"))
+		}
+		if v.Get("destination_server") != "srv2" {
+			t.Errorf("destination_server = %q", v.Get("destination_server"))
+		}
+		if v.Get("label") != "copy-label" {
+			t.Errorf("label = %q", v.Get("label"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).Copy(context.Background(), CopyRequest{
+		SourceServer: "srv1", Name: "stack1",
+		DestinationServer: "srv2", Label: "copy-label",
+	})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if got.Return.ID != 12345 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
+	}
+}
+
+func TestOverwrite_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/stack/overwrite.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := readForm(t, r)
+		if v.Get("source_server") != "srv1" {
+			t.Errorf("source_server = %q", v.Get("source_server"))
+		}
+		if v.Get("name") != "stack1" {
+			t.Errorf("name = %q", v.Get("name"))
+		}
+		if v.Get("destination_server") != "srv2" {
+			t.Errorf("destination_server = %q", v.Get("destination_server"))
+		}
+		if v.Get("destination_stack") != "stack2" {
+			t.Errorf("destination_stack = %q (note: not destination_name)", v.Get("destination_stack"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).Overwrite(context.Background(), OverwriteRequest{
+		SourceServer: "srv1", Name: "stack1",
+		DestinationServer: "srv2", DestinationStack: "stack2",
+	})
+	if err != nil {
+		t.Fatalf("Overwrite: %v", err)
+	}
+	if got.Return.ID != 12345 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
+	}
+}
+
+func TestBackup_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/stack/backup.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := readForm(t, r)
+		if v.Get("server") != "srv1" || v.Get("name") != "stack1" {
+			t.Errorf("server=%q name=%q", v.Get("server"), v.Get("name"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).Backup(context.Background(), BackupRequest{
+		ServerName: "srv1", Name: "stack1",
+	})
+	if err != nil {
+		t.Fatalf("Backup: %v", err)
+	}
+	if got.Return.ID != 12345 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
+	}
+}
+
+func TestPurgeCache_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/stack/purge_cache.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := readForm(t, r)
+		if v.Get("server") != "srv1" || v.Get("name") != "stack1" {
+			t.Errorf("server=%q name=%q", v.Get("server"), v.Get("name"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, jobOK)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).PurgeCache(context.Background(), PurgeCacheRequest{
+		ServerName: "srv1", Name: "stack1",
+	})
+	if err != nil {
+		t.Fatalf("PurgeCache: %v", err)
+	}
+	if got.Return.ID != 12345 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
+	}
+}
+
+func TestWrites_StatusFalse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status": false, "msg": "Stack not found"}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	_, err := New(c).Delete(context.Background(), DeleteRequest{ServerName: "srv1", Name: "missing"})
+	if err == nil {
+		t.Fatal("expected error on status:false, got nil")
+	}
+	if !strings.Contains(err.Error(), "Stack not found") {
+		t.Errorf("err = %v", err)
+	}
+}

--- a/pkg/api/cloud/volume/add.go
+++ b/pkg/api/cloud/volume/add.go
@@ -1,0 +1,47 @@
+package volume
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Add creates a new volume on the specified server via
+// "cloud/volume/add.json". ServerName and VolumeName are
+// required; ContainerNames optionally attaches the volume to
+// containers at creation time.
+//
+// The API queues an asynchronous scheduler job; the returned
+// JobResponse carries the job ID for tracking.
+func (s *Client) Add(ctx context.Context, opt AddOptions) (response JobResponse, err error) {
+	if opt.ServerName == "" {
+		return response, fmt.Errorf("volume.Add: ServerName is required")
+	}
+	if opt.VolumeName == "" {
+		return response, fmt.Errorf("volume.Add: VolumeName is required")
+	}
+
+	u := "cloud/volume/add.json"
+
+	keys := []string{"client_id", "server_name", "volume_name", "container_names[]"}
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server_name", opt.ServerName)
+	values.Add("volume_name", opt.VolumeName)
+	for _, name := range opt.ContainerNames {
+		values.Add("container_names[]", name)
+	}
+
+	req, err := s.client.NewRequest("POST", u, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/cloud/volume/add_test.go
+++ b/pkg/api/cloud/volume/add_test.go
@@ -11,7 +11,13 @@ import (
 	"github.com/sitehostnz/gosh/pkg/api"
 )
 
+const (
+	testServerName = "ch-foo"
+	testVolumeName = "data-vol"
+)
+
 func TestAdd_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %q, want POST", r.Method)
@@ -22,10 +28,10 @@ func TestAdd_Success(t *testing.T) {
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("ParseForm: %v", err)
 		}
-		if got := r.Form.Get("server_name"); got != "ch-foo" {
+		if got := r.Form.Get("server_name"); got != testServerName {
 			t.Errorf("server_name = %q", got)
 		}
-		if got := r.Form.Get("volume_name"); got != "data-vol" {
+		if got := r.Form.Get("volume_name"); got != testVolumeName {
 			t.Errorf("volume_name = %q", got)
 		}
 		if got := r.Form["container_names[]"]; len(got) != 2 || got[0] != "cc1" || got[1] != "cc2" {
@@ -38,18 +44,19 @@ func TestAdd_Success(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
 	got, err := New(c).Add(context.Background(), AddOptions{
-		ServerName: "ch-foo", VolumeName: "data-vol",
+		ServerName: testServerName, VolumeName: testVolumeName,
 		ContainerNames: []string{"cc1", "cc2"},
 	})
 	if err != nil {
 		t.Fatalf("Add: %v", err)
 	}
-	if got.Return.Job.ID != 29658430 {
-		t.Errorf("Job.ID = %d, want 29658430", got.Return.Job.ID)
+	if got.Return.ID != 29658430 {
+		t.Errorf("Job.ID = %d, want 29658430", got.Return.ID)
 	}
 }
 
 func TestAdd_RequiredFields(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	if _, err := New(c).Add(context.Background(), AddOptions{VolumeName: "v"}); err == nil ||
 		!strings.Contains(err.Error(), "ServerName is required") {

--- a/pkg/api/cloud/volume/add_test.go
+++ b/pkg/api/cloud/volume/add_test.go
@@ -1,0 +1,62 @@
+package volume
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestAdd_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/cloud/volume/add.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("server_name"); got != "ch-foo" {
+			t.Errorf("server_name = %q", got)
+		}
+		if got := r.Form.Get("volume_name"); got != "data-vol" {
+			t.Errorf("volume_name = %q", got)
+		}
+		if got := r.Form["container_names[]"]; len(got) != 2 || got[0] != "cc1" || got[1] != "cc2" {
+			t.Errorf("container_names[] = %v, want [cc1 cc2]", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":29658430,"type":"scheduler"}}}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).Add(context.Background(), AddOptions{
+		ServerName: "ch-foo", VolumeName: "data-vol",
+		ContainerNames: []string{"cc1", "cc2"},
+	})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if got.Return.Job.ID != 29658430 {
+		t.Errorf("Job.ID = %d, want 29658430", got.Return.Job.ID)
+	}
+}
+
+func TestAdd_RequiredFields(t *testing.T) {
+	c, _ := api.New("k", "1")
+	if _, err := New(c).Add(context.Background(), AddOptions{VolumeName: "v"}); err == nil ||
+		!strings.Contains(err.Error(), "ServerName is required") {
+		t.Errorf("missing ServerName: err = %v", err)
+	}
+	if _, err := New(c).Add(context.Background(), AddOptions{ServerName: "s"}); err == nil ||
+		!strings.Contains(err.Error(), "VolumeName is required") {
+		t.Errorf("missing VolumeName: err = %v", err)
+	}
+}

--- a/pkg/api/cloud/volume/delete.go
+++ b/pkg/api/cloud/volume/delete.go
@@ -1,0 +1,42 @@
+package volume
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Delete removes a volume via "cloud/volume/delete.json". Both
+// Server and Volume are required. Note the parameter names
+// follow the get convention (server / volume) rather than the
+// add convention (server_name / volume_name) — see the
+// DeleteOptions doc comment.
+func (s *Client) Delete(ctx context.Context, opt DeleteOptions) (response JobResponse, err error) {
+	if opt.Server == "" {
+		return response, fmt.Errorf("volume.Delete: Server is required")
+	}
+	if opt.Volume == "" {
+		return response, fmt.Errorf("volume.Delete: Volume is required")
+	}
+
+	u := "cloud/volume/delete.json"
+
+	keys := []string{"client_id", "server", "volume"}
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server", opt.Server)
+	values.Add("volume", opt.Volume)
+
+	req, err := s.client.NewRequest("POST", u, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/cloud/volume/delete_test.go
+++ b/pkg/api/cloud/volume/delete_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestDelete_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/volume/delete.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -19,10 +20,10 @@ func TestDelete_Success(t *testing.T) {
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("ParseForm: %v", err)
 		}
-		if got := r.Form.Get("server"); got != "ch-foo" {
+		if got := r.Form.Get("server"); got != testServerName {
 			t.Errorf("server = %q (note: not server_name)", got)
 		}
-		if got := r.Form.Get("volume"); got != "data-vol" {
+		if got := r.Form.Get("volume"); got != testVolumeName {
 			t.Errorf("volume = %q (note: not volume_name)", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -31,12 +32,13 @@ func TestDelete_Success(t *testing.T) {
 	defer server.Close()
 
 	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
-	if _, err := New(c).Delete(context.Background(), DeleteOptions{Server: "ch-foo", Volume: "data-vol"}); err != nil {
+	if _, err := New(c).Delete(context.Background(), DeleteOptions{Server: testServerName, Volume: testVolumeName}); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
 }
 
 func TestDelete_RequiredFields(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	if _, err := New(c).Delete(context.Background(), DeleteOptions{}); err == nil ||
 		!strings.Contains(err.Error(), "Server is required") {

--- a/pkg/api/cloud/volume/delete_test.go
+++ b/pkg/api/cloud/volume/delete_test.go
@@ -1,0 +1,45 @@
+package volume
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestDelete_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/volume/delete.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("server"); got != "ch-foo" {
+			t.Errorf("server = %q (note: not server_name)", got)
+		}
+		if got := r.Form.Get("volume"); got != "data-vol" {
+			t.Errorf("volume = %q (note: not volume_name)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":42,"type":"scheduler"}}}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	if _, err := New(c).Delete(context.Background(), DeleteOptions{Server: "ch-foo", Volume: "data-vol"}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestDelete_RequiredFields(t *testing.T) {
+	c, _ := api.New("k", "1")
+	if _, err := New(c).Delete(context.Background(), DeleteOptions{}); err == nil ||
+		!strings.Contains(err.Error(), "Server is required") {
+		t.Errorf("missing Server: err = %v", err)
+	}
+}

--- a/pkg/api/cloud/volume/doc.go
+++ b/pkg/api/cloud/volume/doc.go
@@ -1,0 +1,3 @@
+// Package volume represents our SiteHost `/cloud/volume` API endpoint —
+// persistent volumes that can be attached to cloud containers.
+package volume

--- a/pkg/api/cloud/volume/get.go
+++ b/pkg/api/cloud/volume/get.go
@@ -1,0 +1,37 @@
+package volume
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Get retrieves the details for a single volume via
+// "cloud/volume/get.json". Both Server and Volume are required.
+func (s *Client) Get(ctx context.Context, opt GetOptions) (response GetResponse, err error) {
+	if opt.Server == "" {
+		return response, fmt.Errorf("volume.Get: Server is required")
+	}
+	if opt.Volume == "" {
+		return response, fmt.Errorf("volume.Get: Volume is required")
+	}
+
+	u := "cloud/volume/get.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/cloud/volume/get_test.go
+++ b/pkg/api/cloud/volume/get_test.go
@@ -12,14 +12,15 @@ import (
 )
 
 func TestGet_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/volume/get.json" {
 			t.Errorf("path = %q, want /cloud/volume/get.json", r.URL.Path)
 		}
-		if got := r.URL.Query().Get("server"); got != "ch-foo" {
+		if got := r.URL.Query().Get("server"); got != testServerName {
 			t.Errorf("server = %q, want ch-foo (note: not server_name)", got)
 		}
-		if got := r.URL.Query().Get("volume"); got != "data-vol" {
+		if got := r.URL.Query().Get("volume"); got != testVolumeName {
 			t.Errorf("volume = %q, want data-vol (note: not volume_name)", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -38,16 +39,17 @@ func TestGet_Success(t *testing.T) {
 	defer server.Close()
 
 	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
-	got, err := New(c).Get(context.Background(), GetOptions{Server: "ch-foo", Volume: "data-vol"})
+	got, err := New(c).Get(context.Background(), GetOptions{Server: testServerName, Volume: testVolumeName})
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if got.Return.VolumeName != "data-vol" {
+	if got.Return.VolumeName != testVolumeName {
 		t.Errorf("VolumeName = %q", got.Return.VolumeName)
 	}
 }
 
 func TestGet_RequiredFields(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	if _, err := New(c).Get(context.Background(), GetOptions{Volume: "v"}); err == nil ||
 		!strings.Contains(err.Error(), "Server is required") {

--- a/pkg/api/cloud/volume/get_test.go
+++ b/pkg/api/cloud/volume/get_test.go
@@ -1,0 +1,60 @@
+package volume
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestGet_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/volume/get.json" {
+			t.Errorf("path = %q, want /cloud/volume/get.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("server"); got != "ch-foo" {
+			t.Errorf("server = %q, want ch-foo (note: not server_name)", got)
+		}
+		if got := r.URL.Query().Get("volume"); got != "data-vol" {
+			t.Errorf("volume = %q, want data-vol (note: not volume_name)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true, "msg": "Successful",
+			"return": {
+				"id": "100", "client_id": "1234", "server_id": "62994",
+				"pending": "", "volume_name": "data-vol",
+				"is_missing": "0",
+				"date_added": "2026-05-01 00:00:00", "date_updated": "2026-05-02 00:00:00",
+				"server_name": "ch-foo", "server_label": "foo",
+				"server_owner": true, "containers": []
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).Get(context.Background(), GetOptions{Server: "ch-foo", Volume: "data-vol"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Return.VolumeName != "data-vol" {
+		t.Errorf("VolumeName = %q", got.Return.VolumeName)
+	}
+}
+
+func TestGet_RequiredFields(t *testing.T) {
+	c, _ := api.New("k", "1")
+	if _, err := New(c).Get(context.Background(), GetOptions{Volume: "v"}); err == nil ||
+		!strings.Contains(err.Error(), "Server is required") {
+		t.Errorf("missing Server: err = %v", err)
+	}
+	if _, err := New(c).Get(context.Background(), GetOptions{Server: "s"}); err == nil ||
+		!strings.Contains(err.Error(), "Volume is required") {
+		t.Errorf("missing Volume: err = %v", err)
+	}
+}

--- a/pkg/api/cloud/volume/listall.go
+++ b/pkg/api/cloud/volume/listall.go
@@ -1,0 +1,29 @@
+package volume
+
+import (
+	"context"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// List retrieves all volumes for the authenticated client via
+// "cloud/volume/list_all.json", with optional filters.
+func (s *Client) List(ctx context.Context, opt *ListOptions) (response ListResponse, err error) {
+	u := "cloud/volume/list_all.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/cloud/volume/listall_test.go
+++ b/pkg/api/cloud/volume/listall_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestList_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/volume/list_all.json" {
 			t.Errorf("path = %q, want /cloud/volume/list_all.json", r.URL.Path)
@@ -61,6 +62,7 @@ func TestList_Success(t *testing.T) {
 }
 
 func TestList_Filters(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Query().Get("filters[server_name]"); got != "ch-foo" {
 			t.Errorf("filters[server_name] = %q", got)

--- a/pkg/api/cloud/volume/listall_test.go
+++ b/pkg/api/cloud/volume/listall_test.go
@@ -1,0 +1,77 @@
+package volume
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestList_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/volume/list_all.json" {
+			t.Errorf("path = %q, want /cloud/volume/list_all.json", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful",
+			"return": {
+				"current_items": 1,
+				"current_page": 1,
+				"total_pages": 1,
+				"total_items": 1,
+				"data": [
+					{
+						"id": "100", "client_id": "1234", "server_id": "62994",
+						"pending": "", "volume_name": "data-vol",
+						"is_missing": "0",
+						"date_added": "2026-05-01 00:00:00", "date_updated": "2026-05-02 00:00:00",
+						"server_name": "ch-foo", "server_label": "foo",
+						"server_owner": true,
+						"containers": ["cc1234"]
+					}
+				]
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).List(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got.Return.Data) != 1 {
+		t.Fatalf("len(Data) = %d, want 1", len(got.Return.Data))
+	}
+	v := got.Return.Data[0]
+	if v.VolumeName != "data-vol" {
+		t.Errorf("VolumeName = %q", v.VolumeName)
+	}
+	if !v.ServerOwner {
+		t.Errorf("ServerOwner = false, want true")
+	}
+	if len(v.Containers) != 1 || v.Containers[0] != "cc1234" {
+		t.Errorf("Containers = %v, want [cc1234]", v.Containers)
+	}
+}
+
+func TestList_Filters(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("filters[server_name]"); got != "ch-foo" {
+			t.Errorf("filters[server_name] = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"data":[]}}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	if _, err := New(c).List(context.Background(), &ListOptions{ServerName: "ch-foo"}); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+}

--- a/pkg/api/cloud/volume/models.go
+++ b/pkg/api/cloud/volume/models.go
@@ -1,0 +1,17 @@
+package volume
+
+import (
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+type (
+	// Client is a Service to work with the SiteHost Cloud Volume API.
+	Client struct {
+		client *api.Client
+	}
+)
+
+// New is an initialisation function.
+func New(c *api.Client) *Client {
+	return &Client{client: c}
+}

--- a/pkg/api/cloud/volume/mount.go
+++ b/pkg/api/cloud/volume/mount.go
@@ -1,0 +1,55 @@
+package volume
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Mount attaches a volume to one or more containers via
+// "cloud/volume/mount.json". ServerName, VolumeName, and at
+// least one Container are required.
+//
+// The API expects a nested form-encoded shape:
+//
+//	containers[<stack_name>][] = <container_name>
+//
+// repeated for each (StackName, ContainerName) pair. Returned
+// JobResponse carries the scheduler job ID.
+func (s *Client) Mount(ctx context.Context, opt MountOptions) (response JobResponse, err error) {
+	if opt.ServerName == "" {
+		return response, fmt.Errorf("volume.Mount: ServerName is required")
+	}
+	if opt.VolumeName == "" {
+		return response, fmt.Errorf("volume.Mount: VolumeName is required")
+	}
+	if len(opt.Containers) == 0 {
+		return response, fmt.Errorf("volume.Mount: at least one Container is required")
+	}
+
+	u := "cloud/volume/mount.json"
+
+	keys := []string{"client_id", "server_name", "volume_name"}
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server_name", opt.ServerName)
+	values.Add("volume_name", opt.VolumeName)
+	for _, c := range opt.Containers {
+		k := fmt.Sprintf("containers[%s][]", c.StackName)
+		values.Add(k, c.ContainerName)
+		keys = append(keys, k)
+	}
+
+	req, err := s.client.NewRequest("POST", u, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/cloud/volume/mount_test.go
+++ b/pkg/api/cloud/volume/mount_test.go
@@ -1,0 +1,46 @@
+package volume
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestMount_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/volume/mount.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form["containers[mystack][]"]; len(got) != 1 || got[0] != "container-a" {
+			t.Errorf("containers[mystack][] = %v, want [container-a]", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":1,"type":"scheduler"}}}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	if _, err := New(c).Mount(context.Background(), MountOptions{
+		ServerName: "ch-foo", VolumeName: "data-vol",
+		Containers: []ContainerMount{{StackName: "mystack", ContainerName: "container-a"}},
+	}); err != nil {
+		t.Fatalf("Mount: %v", err)
+	}
+}
+
+func TestMount_RequiredContainer(t *testing.T) {
+	c, _ := api.New("k", "1")
+	if _, err := New(c).Mount(context.Background(), MountOptions{
+		ServerName: "ch-foo", VolumeName: "data-vol",
+	}); err == nil || !strings.Contains(err.Error(), "Container is required") {
+		t.Errorf("missing Container: err = %v", err)
+	}
+}

--- a/pkg/api/cloud/volume/mount_test.go
+++ b/pkg/api/cloud/volume/mount_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMount_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/volume/mount.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -37,6 +38,7 @@ func TestMount_Success(t *testing.T) {
 }
 
 func TestMount_RequiredContainer(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	if _, err := New(c).Mount(context.Background(), MountOptions{
 		ServerName: "ch-foo", VolumeName: "data-vol",

--- a/pkg/api/cloud/volume/request.go
+++ b/pkg/api/cloud/volume/request.go
@@ -1,0 +1,68 @@
+package volume
+
+type (
+	// ListOptions represents optional filters for the list_all
+	// call. All fields are optional.
+	ListOptions struct {
+		Name       string `url:"filters[name],omitempty"`
+		ServerName string `url:"filters[server_name],omitempty"`
+		Container  string `url:"filters[container],omitempty"`
+		SortBy     string `url:"filters[sort_by],omitempty"`
+		SortDir    string `url:"filters[sort_dir],omitempty"`
+		PageSize   int    `url:"filters[page_size],omitempty"`
+		PageNumber int    `url:"filters[page_number],omitempty"`
+	}
+
+	// GetOptions identifies the volume to fetch.
+	//
+	// Note: get and delete use the unprefixed parameter names
+	// (server / volume) — distinct from add / mount /
+	// update_mounts which use server_name / volume_name. This
+	// reflects the API's actual surface; tags are explicit.
+	GetOptions struct {
+		Server string `url:"server"`
+		Volume string `url:"volume"`
+	}
+
+	// DeleteOptions identifies the volume to delete. Same
+	// parameter naming as GetOptions.
+	DeleteOptions struct {
+		Server string `url:"server"`
+		Volume string `url:"volume"`
+	}
+
+	// AddOptions describes a new volume to create. ContainerNames
+	// is an optional list of container identifiers to attach the
+	// volume to at creation time.
+	AddOptions struct {
+		ServerName     string
+		VolumeName     string
+		ContainerNames []string
+	}
+
+	// ContainerMount describes a single container target for
+	// volume mount / unmount operations: the stack the container
+	// belongs to and the container's name.
+	ContainerMount struct {
+		StackName     string
+		ContainerName string
+	}
+
+	// MountOptions describes a volume to mount and the containers
+	// to mount it to.
+	MountOptions struct {
+		ServerName string
+		VolumeName string
+		Containers []ContainerMount
+	}
+
+	// UpdateMountsOptions describes incremental mount changes —
+	// containers to attach (Add) and detach (Remove). Either or
+	// both may be set.
+	UpdateMountsOptions struct {
+		ServerName string
+		VolumeName string
+		Add        []ContainerMount
+		Remove     []ContainerMount
+	}
+)

--- a/pkg/api/cloud/volume/response.go
+++ b/pkg/api/cloud/volume/response.go
@@ -13,18 +13,18 @@ type (
 	// Containers is a list of container identifiers the volume is
 	// currently attached to; empty when not mounted anywhere.
 	Volume struct {
-		ID           string   `json:"id"`
-		ClientID     string   `json:"client_id"`
-		ServerID     string   `json:"server_id"`
-		Pending      string   `json:"pending"`
-		VolumeName   string   `json:"volume_name"`
-		IsMissing    string   `json:"is_missing"`
-		DateAdded    string   `json:"date_added"`
-		DateUpdated  string   `json:"date_updated"`
-		ServerName   string   `json:"server_name"`
-		ServerLabel  string   `json:"server_label"`
-		ServerOwner  bool     `json:"server_owner"`
-		Containers   []string `json:"containers"`
+		ID          string   `json:"id"`
+		ClientID    string   `json:"client_id"`
+		ServerID    string   `json:"server_id"`
+		Pending     string   `json:"pending"`
+		VolumeName  string   `json:"volume_name"`
+		IsMissing   string   `json:"is_missing"`
+		DateAdded   string   `json:"date_added"`
+		DateUpdated string   `json:"date_updated"`
+		ServerName  string   `json:"server_name"`
+		ServerLabel string   `json:"server_label"`
+		ServerOwner bool     `json:"server_owner"`
+		Containers  []string `json:"containers"`
 	}
 
 	// ListResponse represents the response from list_all.

--- a/pkg/api/cloud/volume/response.go
+++ b/pkg/api/cloud/volume/response.go
@@ -1,0 +1,55 @@
+package volume
+
+import "github.com/sitehostnz/gosh/pkg/models"
+
+type (
+	// Volume describes a single cloud volume.
+	//
+	// String-typed boolean fields (IsMissing) reflect the API's
+	// actual response shape ("0"/"1"). Pending is non-empty while
+	// an operation is in flight (e.g. "adding:29658430"); empty
+	// when stable.
+	//
+	// Containers is a list of container identifiers the volume is
+	// currently attached to; empty when not mounted anywhere.
+	Volume struct {
+		ID           string   `json:"id"`
+		ClientID     string   `json:"client_id"`
+		ServerID     string   `json:"server_id"`
+		Pending      string   `json:"pending"`
+		VolumeName   string   `json:"volume_name"`
+		IsMissing    string   `json:"is_missing"`
+		DateAdded    string   `json:"date_added"`
+		DateUpdated  string   `json:"date_updated"`
+		ServerName   string   `json:"server_name"`
+		ServerLabel  string   `json:"server_label"`
+		ServerOwner  bool     `json:"server_owner"`
+		Containers   []string `json:"containers"`
+	}
+
+	// ListResponse represents the response from list_all.
+	ListResponse struct {
+		Return struct {
+			models.Pagination
+			Data []Volume `json:"data"`
+		} `json:"return"`
+		models.APIResponse
+	}
+
+	// GetResponse represents the response from get.
+	GetResponse struct {
+		Return Volume `json:"return"`
+		models.APIResponse
+	}
+
+	// JobResponse is the shared response shape for the write
+	// operations (add, delete, mount, update_mounts). Each
+	// queues an asynchronous scheduler job; the job ID is
+	// returned for tracking.
+	JobResponse struct {
+		Return struct {
+			models.Job `json:"job"`
+		} `json:"return"`
+		models.APIResponse
+	}
+)

--- a/pkg/api/cloud/volume/updatemounts.go
+++ b/pkg/api/cloud/volume/updatemounts.go
@@ -1,0 +1,61 @@
+package volume
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// UpdateMounts incrementally adds or removes container mount
+// targets for a volume via "cloud/volume/update_mounts.json".
+// ServerName and VolumeName are required; at least one of Add
+// or Remove must contain a container.
+//
+// Wire shape:
+//
+//	containers[add][<stack_name>][] = <container_name>
+//	containers[remove][<stack_name>][] = <container_name>
+//
+// Returned JobResponse carries the scheduler job ID.
+func (s *Client) UpdateMounts(ctx context.Context, opt UpdateMountsOptions) (response JobResponse, err error) {
+	if opt.ServerName == "" {
+		return response, fmt.Errorf("volume.UpdateMounts: ServerName is required")
+	}
+	if opt.VolumeName == "" {
+		return response, fmt.Errorf("volume.UpdateMounts: VolumeName is required")
+	}
+	if len(opt.Add) == 0 && len(opt.Remove) == 0 {
+		return response, fmt.Errorf("volume.UpdateMounts: at least one of Add or Remove must contain a container")
+	}
+
+	u := "cloud/volume/update_mounts.json"
+
+	keys := []string{"client_id", "server_name", "volume_name"}
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("server_name", opt.ServerName)
+	values.Add("volume_name", opt.VolumeName)
+	for _, c := range opt.Add {
+		k := fmt.Sprintf("containers[add][%s][]", c.StackName)
+		values.Add(k, c.ContainerName)
+		keys = append(keys, k)
+	}
+	for _, c := range opt.Remove {
+		k := fmt.Sprintf("containers[remove][%s][]", c.StackName)
+		values.Add(k, c.ContainerName)
+		keys = append(keys, k)
+	}
+
+	req, err := s.client.NewRequest("POST", u, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/cloud/volume/updatemounts_test.go
+++ b/pkg/api/cloud/volume/updatemounts_test.go
@@ -1,0 +1,50 @@
+package volume
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestUpdateMounts_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/volume/update_mounts.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form["containers[add][stackA][]"]; len(got) != 1 || got[0] != "addme" {
+			t.Errorf("containers[add][stackA][] = %v, want [addme]", got)
+		}
+		if got := r.Form["containers[remove][stackB][]"]; len(got) != 1 || got[0] != "removeme" {
+			t.Errorf("containers[remove][stackB][] = %v, want [removeme]", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":2,"type":"scheduler"}}}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	if _, err := New(c).UpdateMounts(context.Background(), UpdateMountsOptions{
+		ServerName: "ch-foo", VolumeName: "data-vol",
+		Add:    []ContainerMount{{StackName: "stackA", ContainerName: "addme"}},
+		Remove: []ContainerMount{{StackName: "stackB", ContainerName: "removeme"}},
+	}); err != nil {
+		t.Fatalf("UpdateMounts: %v", err)
+	}
+}
+
+func TestUpdateMounts_AtLeastOneRequired(t *testing.T) {
+	c, _ := api.New("k", "1")
+	if _, err := New(c).UpdateMounts(context.Background(), UpdateMountsOptions{
+		ServerName: "ch-foo", VolumeName: "data-vol",
+	}); err == nil || !strings.Contains(err.Error(), "at least one of Add or Remove") {
+		t.Errorf("missing Add/Remove: err = %v", err)
+	}
+}

--- a/pkg/api/cloud/volume/updatemounts_test.go
+++ b/pkg/api/cloud/volume/updatemounts_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestUpdateMounts_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/volume/update_mounts.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -41,6 +42,7 @@ func TestUpdateMounts_Success(t *testing.T) {
 }
 
 func TestUpdateMounts_AtLeastOneRequired(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	if _, err := New(c).UpdateMounts(context.Background(), UpdateMountsOptions{
 		ServerName: "ch-foo", VolumeName: "data-vol",

--- a/pkg/models/client.go
+++ b/pkg/models/client.go
@@ -13,4 +13,9 @@ type ClientBase struct {
 	// API Credentials
 	APIKey   string
 	ClientID string
+
+	// Host for the GitLab instance backing custom-image repositories.
+	// Defaults to "gitlab-clients.sitehost.co.nz". Override via
+	// api.SetCustomImageGitHost for staging/test environments.
+	CustomImageGitHost string
 }


### PR DESCRIPTION
## Summary

Consolidates the full cloud namespace. Folds 6 prior per-feature
branches — the largest of the per-namespace consolidations.

Surface:

- Stack writes (compose body for HTTP services)
- `cloud.db` + grants (with username-shape constraints documented)
- `cloud.ssh.user` CRUD
- `cloud.server.config` writes (vnc_token, upgrade)
- Image management with helpers: `ForkFromImage`, `WaitForBuild`,
  `LintManifest`, `DeleteAndWait`
- Volume CRUD
- New `pkg/api/cloud/stack/ssl/letsencrypt` sub-package

## Cross-cutting change (in scope but worth flagging)

This PR adds a `CustomImageGitHost` field to `models.ClientBase` and
a `SetCustomImageGitHost` `ClientOpt`, defaulting to
`"gitlab-clients.sitehost.co.nz"`. The `cloud.image.CloneURL` helper
uses this; the value is customer-visible via Control Panel. It's a
public-API-surface change that affects every consumer of the SDK,
not just cloud-package users — surfacing here so it doesn't sneak
through with the namespace work.

## Live findings captured at the wrapper level

- Cloud Container Server image quota is enforced at write-time
  (per-CCS limit; not visible from list endpoints)
- DB Add holds a container-lock; concurrent calls against the same
  container are rejected — wait between Adds

## Review-feedback fixes

1. **`letsencrypt.ListRequest`** now sends the required `name`
   (StackName) param plus an optional `containers` filter. Previous
   shape sent only `server` and got "The stack name is missing." on
   every live call. Doc reframed: Return map is keyed by container
   name (within the queried stack), not stack name.
2. **`image.ForkFromImage`** now resolves the public parent via
   `cloud.stack.image.List` (the platform catalogue with
   `is_public:true` images) rather than `cloud.image.List` (the
   customer-only endpoint). Bootstrap accounts have no own-images,
   so the previous lookup always missed public parents.
3. **`stack/add.go` doc** corrected: "hostname is invalid" rejection
   is on the compose body's `nz.sitehost.container.label`, not the
   API `Label` param.
4. **Dangling example/doc references dropped** in `cloud/server`,
   `cloud/ssh/user/delete`, `cloud/stack/add`, `cloud/stack/ssl/letsencrypt`.
5. **`CustomImageGitHost` change** called out above (was missing
   from this description).

## Test plan

- [x] unit tests across the full surface, updated for the new
      ListRequest shape + ForkFromImage catalogue lookup
- [x] live-validated end-to-end against zero-cost AKL01/AKL02/SYD01
      regions (build → image-fork → stack-deploy → db-add → tear-down)