### PR TITLE
srs: full registry namespace — 37 endpoints (reads + lifecycle + writes)

### DIFF
--- a/pkg/api/srs/autorenew.go
+++ b/pkg/api/srs/autorenew.go
@@ -1,0 +1,48 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// UpdateAutoRenewOptions configures the auto-renew schedule for a
+// domain. All four fields are required by the API.
+//
+// Term is the renewal-period length in months (12 = 1 year, etc.).
+// Set Term to 0 to disable auto-renew (verify by reading
+// srs.GetDomain(domain).AutorenewTerm afterwards — value 0 means
+// disabled).
+//
+// DaysRemaining controls how many days before expiry the renewal
+// fires (e.g. 30 = renew 30 days before billed-until date).
+type UpdateAutoRenewOptions struct {
+	Domain        string `url:"domain"`
+	Term          int    `url:"term"`
+	DaysRemaining int    `url:"days_remaining"`
+}
+
+// UpdateAutoRenew configures the auto-renew schedule for a domain
+// via "srs/update_auto_renew.json".
+//
+// Verify the new schedule via srs.GetDomain(domain).AutorenewTerm
+// + AutorenewDaysRemaining.
+func (s *Client) UpdateAutoRenew(ctx context.Context, opt UpdateAutoRenewOptions) (response models.APIResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.UpdateAutoRenew: Domain is required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/update_auto_renew.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/companyresponse.go
+++ b/pkg/api/srs/companyresponse.go
@@ -1,0 +1,27 @@
+package srs
+
+import "github.com/sitehostnz/gosh/pkg/models"
+
+type (
+	// CompanyInfo describes the client's company profile.
+	CompanyInfo struct {
+		ClientID             int    `json:"client_id"`
+		CompanyName          string `json:"companyname"`
+		CompanyURL           string `json:"companyurl"`
+		CompanyRenewURL      string `json:"companyrenewurl"`
+		CompanyEmail         string `json:"companyemail"`
+		CompanyEmailFrom     string `json:"companyemailfrom"`
+		CompanyEmailFromName string `json:"companyemailfromname"`
+		CompanySupportEmail  string `json:"companysupportemail"`
+		CompanyPhone         string `json:"companyphone"`
+		CompanyFax           string `json:"companyfax"`
+		SendRenewedEmail     string `json:"send_renewed_email"`
+		SendInvoice          string `json:"send_invoice"`
+	}
+
+	// GetCompanyInfoResponse represents the response from get_company_info.
+	GetCompanyInfoResponse struct {
+		Return CompanyInfo `json:"return"`
+		models.APIResponse
+	}
+)

--- a/pkg/api/srs/contact_writes.go
+++ b/pkg/api/srs/contact_writes.go
@@ -1,0 +1,277 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// CreateContactOptions describes a new domain contact for the
+// Shared Registry System (POST srs/create_contact.json).
+//
+// # Wire schema (per docs.sitehost.nz, May 2026)
+//
+// The endpoint is form-encoded. Two naming conventions coexist:
+//
+//   - Top-level (no params[] wrapper): name, email, postal_address,
+//     postal_address2, suburb, city, country.
+//   - params[<PascalCase>] for everything else: PostCode, Province,
+//     Organization.
+//   - params[<Group>][<Field>] for the three phone-style numbers:
+//     params[Phone][Country|Area|Local|Extension] and identical
+//     shapes for Fax and Mobile.
+//
+// Field-name capitalisation matters. Sub-keys are PascalCase
+// (Country, not country / cntry / CountryCode). Lowercase or
+// abbreviated variants are silently rejected with confusing
+// errors like "phone country code number is missing" or "phone
+// number is missing".
+//
+// # Required vs optional (per docs)
+//
+// Required (server-side validated):
+//   - Name, Email
+//   - PostalAddress, PostalAddress2
+//   - City, Country (ISO 2-letter, e.g. "NZ")
+//   - PostCode (params[PostCode])
+//   - Phone: Country, Area, Local (Extension optional)
+//
+// Optional but commonly required by registries:
+//   - Suburb, Province, Organization
+//   - Fax, Mobile (full sub-arrays)
+//
+// # Email TLD constraint (live finding)
+//
+// Email must use a real public-suffix TLD (.com, .nz, …).
+// RFC-2606 reserved TLDs (.example, .test, .invalid) are rejected
+// with "Please specify a valid email address." Use example.com,
+// not example.example.
+//
+// # Phone format
+//
+// Country: digits only, e.g. "64" for NZ.
+// Area: digits only, no leading zero ("9" not "09" — though the
+// API accepts and normalises "09").
+// Local: line number digits only, no separators.
+// Extension: optional digits.
+type CreateContactOptions struct {
+	Name           string `url:"name"`
+	Email          string `url:"email"`
+	PostalAddress  string `url:"postal_address"`
+	PostalAddress2 string `url:"postal_address2"`
+	Suburb         string `url:"suburb,omitempty"`
+	City           string `url:"city"`
+	Country        string `url:"country"`
+	PostCode       string `url:"params[PostCode]"`
+	Province       string `url:"params[Province],omitempty"`
+	Organization   string `url:"params[Organization],omitempty"`
+
+	// Phone is required. Per the published schema: Country, Area,
+	// Local are required; Extension is optional.
+	PhoneCountry   string `url:"params[Phone][Country],omitempty"`
+	PhoneArea      string `url:"params[Phone][Area],omitempty"`
+	PhoneLocal     string `url:"params[Phone][Local],omitempty"`
+	PhoneExtension string `url:"params[Phone][Extension],omitempty"`
+
+	// Fax — fully optional. Same Country/Area/Local/Extension shape.
+	FaxCountry   string `url:"params[Fax][Country],omitempty"`
+	FaxArea      string `url:"params[Fax][Area],omitempty"`
+	FaxLocal     string `url:"params[Fax][Local],omitempty"`
+	FaxExtension string `url:"params[Fax][Extension],omitempty"`
+
+	// Mobile — fully optional. Same Country/Area/Local/Extension
+	// shape. Area on NZ mobiles is the network prefix (e.g. "21").
+	MobileCountry   string `url:"params[Mobile][Country],omitempty"`
+	MobileArea      string `url:"params[Mobile][Area],omitempty"`
+	MobileLocal     string `url:"params[Mobile][Local],omitempty"`
+	MobileExtension string `url:"params[Mobile][Extension],omitempty"`
+}
+
+// CreateContactResponse returns the new contact's id (and a
+// snapshot of the contact body the registry stored).
+//
+// The JSON key is "ContactID" (PascalCase) per the live API.
+type CreateContactResponse struct {
+	Return struct {
+		ContactID string `json:"ContactID"`
+	} `json:"return"`
+	models.APIResponse
+}
+
+// CreateContact registers a new domain contact via
+// "srs/create_contact.json". Returns the new contact's id.
+//
+// Contact fields outside the required set may be left empty; a
+// follow-up UpdateContact can fill them in.
+func (s *Client) CreateContact(ctx context.Context, opt CreateContactOptions) (response CreateContactResponse, err error) {
+	if opt.Name == "" {
+		return response, fmt.Errorf("srs.CreateContact: Name is required")
+	}
+	if opt.Email == "" {
+		return response, fmt.Errorf("srs.CreateContact: Email is required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/create_contact.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// UpdateContactOptions edits an existing contact. Only the fields
+// you set are sent (omitempty everywhere). All field names are
+// PascalCase per the API's params[<Name>] convention.
+type UpdateContactOptions struct {
+	ContactID      int    `url:"contact_id"`
+	Name           string `url:"params[Name],omitempty"`
+	Email          string `url:"params[Email],omitempty"`
+	PostalAddress  string `url:"params[PostalAddress],omitempty"`
+	PostalAddress2 string `url:"params[PostalAddress2],omitempty"`
+	Suburb         string `url:"params[Suburb],omitempty"`
+	City           string `url:"params[City],omitempty"`
+	Country        string `url:"params[Country],omitempty"`
+	PostCode       string `url:"params[PostCode],omitempty"`
+	Province       string `url:"params[Province],omitempty"`
+}
+
+// UpdateContact edits an existing domain contact via
+// "srs/update_contact.json". ContactID is required; only the
+// non-zero / non-empty params[*] fields are sent.
+func (s *Client) UpdateContact(ctx context.Context, opt UpdateContactOptions) (response models.APIResponse, err error) {
+	if opt.ContactID == 0 {
+		return response, fmt.Errorf("srs.UpdateContact: ContactID is required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/update_contact.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// DeleteContactOptions identifies a contact to remove.
+type DeleteContactOptions struct {
+	ContactID int `url:"contact_id"`
+}
+
+// DeleteContact removes a domain contact via
+// "srs/delete_contact.json". The API rejects deletion of contacts
+// currently bound to any domain — unbind first via
+// UpdateDomainContacts.
+func (s *Client) DeleteContact(ctx context.Context, opt DeleteContactOptions) (response models.APIResponse, err error) {
+	if opt.ContactID == 0 {
+		return response, fmt.Errorf("srs.DeleteContact: ContactID is required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/delete_contact.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// UpdateDomainContactsOptions rebinds the four contact roles
+// (registrant / admin / technical / billing) on a domain. All
+// four contact IDs are required by the API except BillingContact
+// per the docs (which marks billing as optional, but in practice
+// most TLDs require it).
+type UpdateDomainContactsOptions struct {
+	Domain              string `url:"domain"`
+	RegistrantContactID int    `url:"registrant_contact_id"`
+	AdminContactID      int    `url:"admin_contact_id"`
+	TechnicalContactID  int    `url:"technical_contact_id"`
+	BillingContactID    int    `url:"billing_contact_id,omitempty"`
+}
+
+// UpdateDomainContacts rebinds the contact roles on a domain via
+// "srs/update_domain_contacts.json".
+//
+// Note .nz registry policy may restrict registrant-name changes
+// (the registrant is the legal owner; transferring it elsewhere
+// is a special operation, not just a contact update). Other
+// roles (admin, tech, billing) typically rebind freely.
+func (s *Client) UpdateDomainContacts(ctx context.Context, opt UpdateDomainContactsOptions) (response models.APIResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.UpdateDomainContacts: Domain is required")
+	}
+	if opt.RegistrantContactID == 0 || opt.AdminContactID == 0 || opt.TechnicalContactID == 0 {
+		return response, fmt.Errorf("srs.UpdateDomainContacts: RegistrantContactID, AdminContactID, TechnicalContactID are all required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/update_domain_contacts.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// UpdateCompanyInfoOptions updates account-level company info
+// (used in registry whois output and renewal email branding).
+// All fields optional — only non-empty fields are sent. Use
+// GetCompanyInfo to read current values before writing.
+type UpdateCompanyInfoOptions struct {
+	CompanyName          string `url:"params[CompanyName],omitempty"`
+	CompanyURL           string `url:"params[CompanyUrl],omitempty"`
+	CompanyRenewURL      string `url:"params[CompanyRenewUrl],omitempty"`
+	CompanyEmail         string `url:"params[CompanyEmail],omitempty"`
+	CompanyEmailFrom     string `url:"params[CompanyEmailFrom],omitempty"`
+	CompanyEmailFromName string `url:"params[CompanyEmailFromName],omitempty"`
+	CompanySupportEmail  string `url:"params[CompanySupportEmail],omitempty"`
+	CompanyPhone         string `url:"params[CompanyPhone],omitempty"`
+	CompanyFax           string `url:"params[CompanyFax],omitempty"`
+	// SendRenewedEmail is "1" for yes, "0" for no. Stringified to
+	// distinguish "unset" (don't send) from explicit-zero ("0",
+	// disable).
+	SendRenewedEmail string `url:"params[SendRenewedEmail],omitempty"`
+}
+
+// UpdateCompanyInfo updates account-level company info via
+// "srs/update_company_info.json".
+//
+// The endpoint affects branding shown in registry whois output
+// and the renewal-email templates. Test against this carefully —
+// mistyped values affect how customers see the account.
+//
+// Best practice: read current values via srs.GetCompanyInfo
+// first, copy them into UpdateCompanyInfoOptions, change only
+// what you need to change, send the rest unchanged.
+func (s *Client) UpdateCompanyInfo(ctx context.Context, opt UpdateCompanyInfoOptions) (response models.APIResponse, err error) {
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/update_company_info.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/contact_writes.go
+++ b/pkg/api/srs/contact_writes.go
@@ -18,7 +18,7 @@ import (
 //   - Top-level (no params[] wrapper): name, email, postal_address,
 //     postal_address2, suburb, city, country.
 //   - params[<PascalCase>] for everything else: PostCode, Province,
-//     Organization.
+//     Organisation (see field name on the struct for the wire key).
 //   - params[<Group>][<Field>] for the three phone-style numbers:
 //     params[Phone][Country|Area|Local|Extension] and identical
 //     shapes for Fax and Mobile.
@@ -39,7 +39,7 @@ import (
 //   - Phone: Country, Area, Local (Extension optional)
 //
 // Optional but commonly required by registries:
-//   - Suburb, Province, Organization
+//   - Suburb, Province, Organisation
 //   - Fax, Mobile (full sub-arrays)
 //
 // # Email TLD constraint (live finding)
@@ -66,7 +66,7 @@ type CreateContactOptions struct {
 	Country        string `url:"country"`
 	PostCode       string `url:"params[PostCode]"`
 	Province       string `url:"params[Province],omitempty"`
-	Organization   string `url:"params[Organization],omitempty"`
+	Organization   string `url:"params[Organization],omitempty"` //nolint:misspell // matches the upstream API wire field name
 
 	// Phone is required. Per the published schema: Country, Area,
 	// Local are required; Extension is optional.

--- a/pkg/api/srs/contact_writes.go
+++ b/pkg/api/srs/contact_writes.go
@@ -29,17 +29,18 @@ import (
 // errors like "phone country code number is missing" or "phone
 // number is missing".
 //
-// # Required vs optional (per docs)
+// # Required vs optional (live finding — diverges from public docs)
 //
 // Required (server-side validated):
 //   - Name, Email
 //   - PostalAddress, PostalAddress2
+//   - Suburb (live: omitting it returns "The suburb is missing.")
 //   - City, Country (ISO 2-letter, e.g. "NZ")
 //   - PostCode (params[PostCode])
 //   - Phone: Country, Area, Local (Extension optional)
 //
 // Optional but commonly required by registries:
-//   - Suburb, Province, Organisation
+//   - Province, Organisation
 //   - Fax, Mobile (full sub-arrays)
 //
 // # Email TLD constraint (live finding)
@@ -61,7 +62,7 @@ type CreateContactOptions struct {
 	Email          string `url:"email"`
 	PostalAddress  string `url:"postal_address"`
 	PostalAddress2 string `url:"postal_address2"`
-	Suburb         string `url:"suburb,omitempty"`
+	Suburb         string `url:"suburb"`
 	City           string `url:"city"`
 	Country        string `url:"country"`
 	PostCode       string `url:"params[PostCode]"`

--- a/pkg/api/srs/contact_writes_test.go
+++ b/pkg/api/srs/contact_writes_test.go
@@ -1,0 +1,159 @@
+package srs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestCreateContact_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/srs/create_contact.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := formBody(t, r)
+		if v.Get("name") != "Test" || v.Get("email") != "t@example.com" {
+			t.Errorf("body = %v", v)
+		}
+		if v.Get("country") != "NZ" || v.Get("params[PostCode]") != "1010" {
+			t.Errorf("missing required: %v", v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Phone fields encode as params[Phone][Country] etc.
+		if v.Get("params[Phone][Country]") != "64" {
+			t.Errorf("Phone[Country] = %q", v.Get("params[Phone][Country]"))
+		}
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"ContactID":"233801"}}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).CreateContact(context.Background(), CreateContactOptions{
+		Name: "Test", Email: "t@example.com",
+		PostalAddress: "1 Test St", PostalAddress2: "",
+		City: "Auckland", Country: "NZ", PostCode: "1010",
+		PhoneCountry: "64", PhoneArea: "9", PhoneLocal: "9742182",
+	})
+	if err != nil {
+		t.Fatalf("CreateContact: %v", err)
+	}
+	if got.Return.ContactID != "233801" {
+		t.Errorf("ContactID = %q", got.Return.ContactID)
+	}
+}
+
+func TestCreateContact_RequiresNameAndEmail(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	if _, err := New(c).CreateContact(context.Background(), CreateContactOptions{Email: "x"}); err == nil {
+		t.Fatal("expected error for missing Name")
+	}
+	if _, err := New(c).CreateContact(context.Background(), CreateContactOptions{Name: "x"}); err == nil {
+		t.Fatal("expected error for missing Email")
+	}
+}
+
+func TestUpdateContact_OmitsEmptyFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := formBody(t, r)
+		if v.Get("contact_id") != "100" {
+			t.Errorf("contact_id = %q", v.Get("contact_id"))
+		}
+		if v.Get("params[Email]") != "new@example.com" {
+			t.Errorf("Email = %q", v.Get("params[Email]"))
+		}
+		// City wasn't set → must be omitted
+		if _, ok := v["params[City]"]; ok {
+			t.Errorf("params[City] should be omitted")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK"}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).UpdateContact(context.Background(), UpdateContactOptions{
+		ContactID: 100, Email: "new@example.com",
+	}); err != nil {
+		t.Fatalf("UpdateContact: %v", err)
+	}
+}
+
+func TestDeleteContact_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/srs/delete_contact.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := formBody(t, r)
+		if v.Get("contact_id") != "12" {
+			t.Errorf("contact_id = %q", v.Get("contact_id"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK"}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).DeleteContact(context.Background(), DeleteContactOptions{ContactID: 12}); err != nil {
+		t.Fatalf("DeleteContact: %v", err)
+	}
+}
+
+func TestUpdateDomainContacts_RequiresThreeRoles(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	// Missing TechnicalContactID
+	if _, err := New(c).UpdateDomainContacts(context.Background(), UpdateDomainContactsOptions{
+		Domain: "example.com", RegistrantContactID: 1, AdminContactID: 2,
+	}); err == nil {
+		t.Fatal("expected error for missing TechnicalContactID")
+	}
+}
+
+func TestUpdateDomainContacts_BillingOptional(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := formBody(t, r)
+		if v.Get("registrant_contact_id") != "10" {
+			t.Errorf("registrant = %q", v.Get("registrant_contact_id"))
+		}
+		// Billing not set → should be omitted
+		if _, ok := v["billing_contact_id"]; ok {
+			t.Errorf("billing should be omitted when zero")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK"}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).UpdateDomainContacts(context.Background(), UpdateDomainContactsOptions{
+		Domain: "example.com", RegistrantContactID: 10,
+		AdminContactID: 11, TechnicalContactID: 12,
+	}); err != nil {
+		t.Fatalf("UpdateDomainContacts: %v", err)
+	}
+}
+
+func TestUpdateCompanyInfo_OnlySendsSetFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := formBody(t, r)
+		if v.Get("params[CompanyName]") != "TestCo" {
+			t.Errorf("CompanyName = %q", v.Get("params[CompanyName]"))
+		}
+		if _, ok := v["params[CompanyPhone]"]; ok {
+			t.Errorf("CompanyPhone should be omitted when unset")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK"}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).UpdateCompanyInfo(context.Background(), UpdateCompanyInfoOptions{
+		CompanyName: "TestCo",
+	}); err != nil {
+		t.Fatalf("UpdateCompanyInfo: %v", err)
+	}
+}

--- a/pkg/api/srs/contact_writes_test.go
+++ b/pkg/api/srs/contact_writes_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestCreateContact_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/srs/create_contact.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -47,6 +48,7 @@ func TestCreateContact_Success(t *testing.T) {
 }
 
 func TestCreateContact_RequiresNameAndEmail(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
 	if _, err := New(c).CreateContact(context.Background(), CreateContactOptions{Email: "x"}); err == nil {
 		t.Fatal("expected error for missing Name")
@@ -57,6 +59,7 @@ func TestCreateContact_RequiresNameAndEmail(t *testing.T) {
 }
 
 func TestUpdateContact_OmitsEmptyFields(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v := formBody(t, r)
 		if v.Get("contact_id") != "100" {
@@ -83,6 +86,7 @@ func TestUpdateContact_OmitsEmptyFields(t *testing.T) {
 }
 
 func TestDeleteContact_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/srs/delete_contact.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -103,6 +107,7 @@ func TestDeleteContact_Success(t *testing.T) {
 }
 
 func TestUpdateDomainContacts_RequiresThreeRoles(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
 	// Missing TechnicalContactID
 	if _, err := New(c).UpdateDomainContacts(context.Background(), UpdateDomainContactsOptions{
@@ -113,6 +118,7 @@ func TestUpdateDomainContacts_RequiresThreeRoles(t *testing.T) {
 }
 
 func TestUpdateDomainContacts_BillingOptional(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v := formBody(t, r)
 		if v.Get("registrant_contact_id") != "10" {
@@ -137,6 +143,7 @@ func TestUpdateDomainContacts_BillingOptional(t *testing.T) {
 }
 
 func TestUpdateCompanyInfo_OnlySendsSetFields(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v := formBody(t, r)
 		if v.Get("params[CompanyName]") != "TestCo" {

--- a/pkg/api/srs/contactrequest.go
+++ b/pkg/api/srs/contactrequest.go
@@ -1,0 +1,18 @@
+package srs
+
+type (
+	// ContactOptions identifies a contact by ID.
+	ContactOptions struct {
+		ContactID string `url:"contact_id"`
+	}
+
+	// SearchContactsOptions filters the contact list. At least one
+	// of Name, Email, or RegistrantName must be set.
+	SearchContactsOptions struct {
+		Name           string `url:"query[name],omitempty"`
+		Email          string `url:"query[email],omitempty"`
+		RegistrantName string `url:"query[registrant_name],omitempty"`
+		Offset         int    `url:"offsets[offset],omitempty"`
+		Limit          int    `url:"offsets[limit],omitempty"`
+	}
+)

--- a/pkg/api/srs/contactresponse.go
+++ b/pkg/api/srs/contactresponse.go
@@ -1,0 +1,67 @@
+package srs
+
+import "github.com/sitehostnz/gosh/pkg/models"
+
+type (
+	// ContactSummary is the brief contact entry returned by
+	// list_contacts and search_contacts.
+	ContactSummary struct {
+		ContactID      string `json:"contact_id"`
+		Name           string `json:"name"`
+		RegistrantName string `json:"registrant_name"`
+		Email          string `json:"email"`
+		PhoneCountry   string `json:"phone_cntry"`
+		PhoneArea      string `json:"phone_area"`
+		PhoneLocal     string `json:"phone_local"`
+		PhoneExtension string `json:"phone_extension"`
+		DomainCount    int    `json:"domain_count"`
+	}
+
+	// ListContactsResponse represents the response from list_contacts.
+	// Note: pagination fields are at the top level (not inside Return).
+	ListContactsResponse struct {
+		models.Pagination
+		Return []ContactSummary `json:"return"`
+		models.APIResponse
+	}
+
+	// SearchContactsResponse represents the response from search_contacts.
+	SearchContactsResponse struct {
+		Return []ContactSummary `json:"return"`
+		models.APIResponse
+	}
+
+	// ContactDetail is the full contact record returned by get_contact.
+	// Fields are PascalCase JSON keys.
+	ContactDetail struct {
+		ContactID       int    `json:"ContactID"`
+		ClientID        string `json:"ClientID"`
+		Name            string `json:"Name"`
+		RegistrantName  string `json:"RegistrantName"`
+		Organization    string `json:"Organization"`
+		PostalAddress   string `json:"PostalAddress"`
+		PostalAddress2  string `json:"PostalAddress2"`
+		Suburb          string `json:"Suburb"`
+		PostCode        string `json:"PostCode"`
+		Province        string `json:"Province"`
+		City            string `json:"City"`
+		Country         string `json:"Country"`
+		PhoneCountry    string `json:"PhoneCountry"`
+		PhoneArea       string `json:"PhoneArea"`
+		PhoneLocal      string `json:"PhoneLocal"`
+		PhoneExtension  string `json:"PhoneExtension"`
+		MobileCountry   string `json:"MobileCountry"`
+		MobileArea      string `json:"MobileArea"`
+		MobileLocal     string `json:"MobileLocal"`
+		MobileExtension string `json:"MobileExtension"`
+		FaxCountry      string `json:"FaxCountry"`
+		FaxArea         string `json:"FaxArea"`
+		FaxLocal        string `json:"FaxLocal"`
+	}
+
+	// GetContactResponse represents the response from get_contact.
+	GetContactResponse struct {
+		Return ContactDetail `json:"return"`
+		models.APIResponse
+	}
+)

--- a/pkg/api/srs/contactresponse.go
+++ b/pkg/api/srs/contactresponse.go
@@ -5,6 +5,11 @@ import "github.com/sitehostnz/gosh/pkg/models"
 type (
 	// ContactSummary is the brief contact entry returned by
 	// list_contacts and search_contacts.
+	//
+	// DomainCount uses [Number] because the API returns it as a JSON
+	// number for established contacts (`0`) and as a JSON string for
+	// newly-created contacts (`"0"`) within the same shape — see the
+	// Number type documentation.
 	ContactSummary struct {
 		ContactID      string `json:"contact_id"`
 		Name           string `json:"name"`
@@ -14,7 +19,7 @@ type (
 		PhoneArea      string `json:"phone_area"`
 		PhoneLocal     string `json:"phone_local"`
 		PhoneExtension string `json:"phone_extension"`
-		DomainCount    int    `json:"domain_count"`
+		DomainCount    Number `json:"domain_count"`
 	}
 
 	// ListContactsResponse represents the response from list_contacts.

--- a/pkg/api/srs/contactresponse.go
+++ b/pkg/api/srs/contactresponse.go
@@ -38,7 +38,7 @@ type (
 		ClientID        string `json:"ClientID"`
 		Name            string `json:"Name"`
 		RegistrantName  string `json:"RegistrantName"`
-		Organization    string `json:"Organization"`
+		Organization    string `json:"Organization"` //nolint:misspell // matches the upstream API JSON key
 		PostalAddress   string `json:"PostalAddress"`
 		PostalAddress2  string `json:"PostalAddress2"`
 		Suburb          string `json:"Suburb"`

--- a/pkg/api/srs/contacts.go
+++ b/pkg/api/srs/contacts.go
@@ -1,0 +1,62 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// ListContacts returns all contacts for the authenticated client
+// via "srs/list_contacts.json".
+func (s *Client) ListContacts(ctx context.Context) (response ListContactsResponse, err error) {
+	req, err := s.client.NewRequest("GET", "srs/list_contacts.json", "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// GetContact returns the full record for a single contact via
+// "srs/get_contact.json". ContactID is required.
+func (s *Client) GetContact(ctx context.Context, opt ContactOptions) (response GetContactResponse, err error) {
+	if opt.ContactID == "" {
+		return response, fmt.Errorf("srs.GetContact: ContactID is required")
+	}
+	path, err := net.AddOptions("srs/get_contact.json", opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// SearchContacts returns contacts matching the given filters
+// via "srs/search_contacts.json". At least one of Name, Email,
+// or RegistrantName must be set.
+func (s *Client) SearchContacts(ctx context.Context, opt SearchContactsOptions) (response SearchContactsResponse, err error) {
+	if opt.Name == "" && opt.Email == "" && opt.RegistrantName == "" {
+		return response, fmt.Errorf("srs.SearchContacts: at least one of Name / Email / RegistrantName is required")
+	}
+	path, err := net.AddOptions("srs/search_contacts.json", opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/doc.go
+++ b/pkg/api/srs/doc.go
@@ -1,3 +1,48 @@
-// Package srs represents our SiteHost `/srs` API endpoint — domain
-// registration and whois lookups via the Shared Registry System.
+// Package srs wraps the SiteHost /srs API — domain registration,
+// transfer, contacts, and lifecycle ops via the Shared Registry
+// System.
+//
+// # TLD-policy variation (important)
+//
+// SiteHost's SRS API is a uniform façade over multiple
+// upstream-registry policies — but **not all features apply to
+// every TLD** the registry serves. The API doesn't surface a
+// per-TLD capability matrix; consumers learn about restrictions
+// only when an op rejects with a TLD-specific error message.
+//
+// Confirmed TLD-specific behaviours (May 2026):
+//
+//   - **.nz domains reject LockDomain / UnlockDomain** with "This
+//     domain cannot be locked." The .nz registry uses the UDAI
+//     (transfer authorisation code) model rather than EPP-style
+//     transfer locks. Use NewUDAI / ValidateUDAI for transfer
+//     auth on .nz instead.
+//
+//   - Other TLD-specific quirks are likely (privacy-protection
+//     not supported on some TLDs, contact-update rules differing
+//     between registries, etc.) but haven't been exhaustively
+//     catalogued. Treat any "this domain cannot ..." error as a
+//     TLD-policy signal, not a wrapper bug.
+//
+// **Consumer guidance:** for each write op, call once and check
+// the response. Don't assume a wrapper that works on .com works
+// identically on .nz / .au / .uk / etc. The wrapper produces the
+// well-formed request; the API enforces TLD policy on top.
+//
+// **Open question for the API team** captured at
+// docs/api-issues/srs-tld-capability-matrix.md: could there be a
+// per-TLD capability endpoint so SDK consumers know upfront which
+// ops will be rejected?
+//
+// # Endpoint surface in this package
+//
+// Reads: ListDomains, GetDomain, ListContacts, GetContact,
+// SearchContacts, ListNameServers, ListValidTLDs,
+// GetPricingTiers, GetCompanyInfo, Whois, GetDomainPrice,
+// DomainAvailable, DomainInsideGracePeriod, CanTransferDomain.
+//
+// Writes: CreateDomain, CancelDomain, LockDomain, UnlockDomain,
+// EnablePrivacyProtection, DisablePrivacyProtection,
+// UpdateAutoRenew. (More writes — contacts CRUD, transfer flow,
+// UDAI, name servers — coming in Tier 2+.)
 package srs

--- a/pkg/api/srs/doc.go
+++ b/pkg/api/srs/doc.go
@@ -1,0 +1,3 @@
+// Package srs represents our SiteHost `/srs` API endpoint — domain
+// registration and whois lookups via the Shared Registry System.
+package srs

--- a/pkg/api/srs/doc.go
+++ b/pkg/api/srs/doc.go
@@ -29,10 +29,9 @@
 // identically on .nz / .au / .uk / etc. The wrapper produces the
 // well-formed request; the API enforces TLD policy on top.
 //
-// **Open question for the API team** captured at
-// docs/api-issues/srs-tld-capability-matrix.md: could there be a
-// per-TLD capability endpoint so SDK consumers know upfront which
-// ops will be rejected?
+// **Open question for the API team:** could there be a per-TLD
+// capability endpoint so SDK consumers know upfront which ops will
+// be rejected?
 //
 // # Endpoint surface in this package
 //

--- a/pkg/api/srs/domainrequest.go
+++ b/pkg/api/srs/domainrequest.go
@@ -34,12 +34,12 @@ type (
 	//   - params[BillingContact]
 	// The Go fields use uniform names; tags reflect the wire shape.
 	CreateDomainOptions struct {
-		Domain             string `url:"domain"`
-		Term               int    `url:"term,omitempty"`
-		RegistrantContact  int    `url:"registrant_contact"`
-		AdminContact       int    `url:"params[AdminContact]"`
-		TechnicalContact   int    `url:"params[TechContact]"`
-		BillingContact     int    `url:"params[BillingContact]"`
-		Privacy            string `url:"privacy,omitempty"`
+		Domain            string `url:"domain"`
+		Term              int    `url:"term,omitempty"`
+		RegistrantContact int    `url:"registrant_contact"`
+		AdminContact      int    `url:"params[AdminContact]"`
+		TechnicalContact  int    `url:"params[TechContact]"`
+		BillingContact    int    `url:"params[BillingContact]"`
+		Privacy           string `url:"privacy,omitempty"`
 	}
 )

--- a/pkg/api/srs/domainrequest.go
+++ b/pkg/api/srs/domainrequest.go
@@ -1,0 +1,45 @@
+package srs
+
+type (
+	// ListDomainsOptions represents optional filters for the list_domains
+	// call. SortBy and SortDir control ordering; PageSize and PageNumber
+	// control pagination. All fields are optional.
+	ListDomainsOptions struct {
+		SortBy     string `url:"filters[sort_by],omitempty"`
+		SortDir    string `url:"filters[sort_dir],omitempty"`
+		PageSize   int    `url:"filters[page_size],omitempty"`
+		PageNumber int    `url:"filters[page_number],omitempty"`
+	}
+
+	// DomainOptions identifies a single domain — used by get_domain,
+	// domain_inside_grace_period, get_domain_price,
+	// can_transfer_domain, list_name_servers, and the lifecycle
+	// operations (cancel_domain, lock_domain, unlock_domain).
+	DomainOptions struct {
+		Domain string `url:"domain"`
+	}
+
+	// DomainAvailableOptions checks whether a domain is registrable.
+	DomainAvailableOptions struct {
+		Domain string `url:"domain"`
+	}
+
+	// CreateDomainOptions describes a new .nz domain to register.
+	// Domain and the four contact IDs are required.
+	//
+	// API parameter naming is inconsistent here:
+	//   - registrant_contact (no _id, top-level)
+	//   - params[AdminContact] (PascalCase, nested in params)
+	//   - params[TechContact]  (note: "Tech", not "Technical")
+	//   - params[BillingContact]
+	// The Go fields use uniform names; tags reflect the wire shape.
+	CreateDomainOptions struct {
+		Domain             string `url:"domain"`
+		Term               int    `url:"term,omitempty"`
+		RegistrantContact  int    `url:"registrant_contact"`
+		AdminContact       int    `url:"params[AdminContact]"`
+		TechnicalContact   int    `url:"params[TechContact]"`
+		BillingContact     int    `url:"params[BillingContact]"`
+		Privacy            string `url:"privacy,omitempty"`
+	}
+)

--- a/pkg/api/srs/domainresponse.go
+++ b/pkg/api/srs/domainresponse.go
@@ -1,0 +1,149 @@
+package srs
+
+import "github.com/sitehostnz/gosh/pkg/models"
+
+type (
+	// Domain is a single registered-domain entry from list_domains.
+	//
+	// String-typed numeric / boolean fields (Locked, Private, Pending,
+	// Premium, AutoRenewTerm, AutoRenewDaysRemaining) reflect the API's
+	// actual response shape — values arrive as strings ("0", "1",
+	// "12") rather than typed numbers / bools. Consumers should
+	// convert as needed.
+	//
+	// JSON tag casing is inconsistent because the API itself is —
+	// some fields use snake_case (client_id, domain_id), others
+	// use lowercase-no-underscore (dateregistered, datebilleduntil).
+	// Tags reflect what the API returns, not what's stylistically
+	// uniform.
+	Domain struct {
+		ID                     string `json:"domain_id"`
+		Domain                 string `json:"domain"`
+		State                  string `json:"state"`
+		API                    string `json:"api"`
+		ClientID               string `json:"client_id"`
+		ClientName             string `json:"client_name"`
+		Locked                 string `json:"locked"`
+		Private                string `json:"private"`
+		Pending                string `json:"pending"`
+		Premium                string `json:"premium"`
+		RegistrantName         string `json:"registrant_name"`
+		RegID                  string `json:"reg_id"`
+		RegName                string `json:"reg_name"`
+		AdmID                  string `json:"adm_id"`
+		AdmName                string `json:"adm_name"`
+		TecID                  string `json:"tec_id"`
+		TecName                string `json:"tec_name"`
+		AutoRenewTerm          string `json:"autorenew_term"`
+		AutoRenewDaysRemaining string `json:"autorenew_days_remaining"`
+		DateRegistered         string `json:"dateregistered"`
+		DateModified           string `json:"datemodified"`
+		DateBilledUntil        string `json:"datebilleduntil"`
+		DateCancelled          string `json:"datecancelled"`
+		DateLocked             string `json:"datelocked"`
+	}
+
+	// ListDomainsResponse represents the response from list_domains.
+	// The API returns a paginated wrapper around the data array.
+	ListDomainsResponse struct {
+		Return struct {
+			models.Pagination
+			Data []Domain `json:"data"`
+		} `json:"return"`
+		models.APIResponse
+	}
+
+	// DomainDetail is the full per-domain shape returned by
+	// get_domain. Fields are PascalCase JSON keys matching the
+	// underlying registry schema. RState is a numeric status
+	// code; Locked / Private / Pending / Premium are real bools.
+	DomainDetail struct {
+		ClientID               int    `json:"ClientID"`
+		Domain                 string `json:"Domain"`
+		State                  string `json:"State"`
+		RState                 int    `json:"RState"`
+		AutorenewReminderSent  bool   `json:"autorenew_reminder_sent"`
+		TransferAutorenewSent  bool   `json:"transfer_autorenew_sent"`
+		API                    string `json:"API"`
+		RegistrantName         string `json:"RegistrantName"`
+		DateRegistered         string `json:"DateRegistered"`
+		DateModified           string `json:"DateModified"`
+		DateBilledUntil        string `json:"DateBilledUntil"`
+		DateCancelled          string `json:"DateCancelled"`
+		DatePrebilled          string `json:"dateprebilled"`
+		DateLocked             string `json:"DateLocked"`
+		DateRenewed            string `json:"daterenewed"`
+		AutorenewTerm          int    `json:"autorenew_term"`
+		AutorenewDaysRemaining int    `json:"autorenew_days_remaining"`
+		RegistrantContactID    int    `json:"RegistrantContactID"`
+		AdminContactID         int    `json:"AdminContactID"`
+		TechnicalContactID     int    `json:"TechnicalContactID"`
+		BillingContactID       int    `json:"BillingContactID"`
+		Locked                 bool   `json:"Locked"`
+		Private                bool   `json:"Private"`
+		Pending                bool   `json:"Pending"`
+		TransferStatus         string `json:"TransferStatus"`
+		TransferID             int    `json:"TransferID"`
+		AuthCodeGenerated      string `json:"auth_code_generated"`
+		DateAdded              string `json:"date_added"`
+		DateUpdated            string `json:"date_updated"`
+		Premium                bool   `json:"premium"`
+	}
+
+	// GetDomainResponse represents the response from get_domain.
+	GetDomainResponse struct {
+		Return DomainDetail `json:"return"`
+		models.APIResponse
+	}
+
+	// DomainPrice describes pricing for a single domain.
+	DomainPrice struct {
+		DomainPrice        float64 `json:"DomainPrice"`
+		TotalPrice         float64 `json:"total_price"`
+		TieredPrice        string  `json:"tiered_price"`
+		BasePrice          string  `json:"base_price"`
+		Premium            bool    `json:"premium"`
+		BasePrivacyPrice   string  `json:"base_privacy_price"`
+		TieredPrivacyPrice string  `json:"tiered_privacy_price"`
+	}
+
+	// GetDomainPriceResponse represents the response from
+	// get_domain_price.
+	GetDomainPriceResponse struct {
+		Return DomainPrice `json:"return"`
+		models.APIResponse
+	}
+
+	// CanTransferDomainInfo describes transfer eligibility.
+	CanTransferDomainInfo struct {
+		Domain      string `json:"domain"`
+		CanTransfer bool   `json:"can_transfer"`
+		Reason      string `json:"reason"`
+	}
+
+	// CanTransferDomainResponse represents the response from
+	// can_transfer_domain.
+	CanTransferDomainResponse struct {
+		Return CanTransferDomainInfo `json:"return"`
+		models.APIResponse
+	}
+
+	// BoolResponse is the response shape used by domain_available
+	// and domain_inside_grace_period — Return is just a bool.
+	BoolResponse struct {
+		Return bool `json:"return"`
+		models.APIResponse
+	}
+
+	// JobResponse is the standard response shape for SRS write
+	// operations that queue a scheduler job — create_domain,
+	// cancel_domain, etc. (Note: this matches the JobResponse
+	// pattern used in other gosh packages, but is package-local
+	// to keep srs self-contained.)
+	JobResponse struct {
+		Return struct {
+			models.Job `json:"job"`
+		} `json:"return"`
+		models.APIResponse
+	}
+)

--- a/pkg/api/srs/email_templates.go
+++ b/pkg/api/srs/email_templates.go
@@ -76,18 +76,24 @@ type GetEmailTemplateResponse struct {
 // path with the trailing 's' on "templates" even for a single-
 // template lookup.
 //
-// **Live finding (May 2026, gosh):** the `template` parameter is
-// validated as required ("The template name is missing." when
-// omitted) but no obvious value satisfies it. Probed against a
-// real account, none of the values surfaced by ListEmailTemplates
-// — the human-readable `name` ("Auto-Renew Reminder - 7 Days"),
-// the `type` slug ("AutoRenewReminder"), or the numeric
-// `template_id` ("11239") — were accepted; all returned "The
-// specified template doesn't exist, or you don't have access to
-// it." Use ListEmailTemplates to read template bodies in the
-// meantime; GetEmailTemplate is wrapped for completeness but is
-// effectively unusable until SiteHost clarifies the parameter
-// shape. See docs/api-issues/srs-get-email-template-shape.md.
+// **Live finding (May 2026, gosh):** every plausible value derived
+// from ListEmailTemplates output — the numeric `template_id`
+// ("11239" or its "-13" prefixed form), the type slug
+// ("AutoRenewReminder"), the lowercase variant, the human name
+// ("Auto-Renew Reminder - 7 Days") — returns
+//
+//	200 Error: The specified template doesnt exist, or you dont
+//	have access to it.
+//
+// (sic — API text omits the apostrophes). The lookup-key namespace
+// for this endpoint appears disjoint from ListEmailTemplates'
+// output. Wrapped here for completeness; consumers should expect
+// API-level rejection until the expected input form is clarified.
+//
+// The wrapper's own SDK-level guard fires on empty input
+// ("Template is required") before reaching the API — the API's
+// own missing-parameter rejection ("The template name is missing.")
+// isn't normally observable.
 func (s *Client) GetEmailTemplate(ctx context.Context, opt GetEmailTemplateOptions) (response GetEmailTemplateResponse, err error) {
 	if opt.Template == "" {
 		return response, fmt.Errorf("srs.GetEmailTemplate: Template is required")

--- a/pkg/api/srs/email_templates.go
+++ b/pkg/api/srs/email_templates.go
@@ -1,0 +1,144 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// EmailTemplate is a single registry-email template (renewal
+// reminders, transfer confirmations, etc.).
+//
+// Field decoding matches the live response from
+// list_email_templates: lowercase `name` is the human-readable
+// label, `type` is the slug used internally, `subject` and
+// `template` are the editable bodies. AvailableTags and
+// RequiredTags list the {PLACEHOLDER} substitutions the registry
+// recognises in this template.
+type EmailTemplate struct {
+	TemplateID    string   `json:"template_id"`
+	ClientID      string   `json:"client_id"`
+	Type          string   `json:"type"`
+	Name          string   `json:"name"`
+	Subject       string   `json:"subject"`
+	Template      string   `json:"template"`
+	DateAdded     string   `json:"date_added"`
+	DateUpdated   string   `json:"date_updated"`
+	AvailableTags []string `json:"available_tags"`
+	RequiredTags  []string `json:"required_tags"`
+	Customized    bool     `json:"customized"`
+}
+
+// ListEmailTemplatesResponse is the response from
+// "srs/list_email_templates.json".
+type ListEmailTemplatesResponse struct {
+	Return []EmailTemplate `json:"return"`
+	models.APIResponse
+}
+
+// ListEmailTemplates returns all email templates configured for
+// the authenticated client via "srs/list_email_templates.json"
+// (GET). The template body and subject are returned per template
+// alongside its name.
+//
+// The public docs do not list parameters; only client_id (auto-
+// injected by the SDK). Validate the response shape live before
+// depending on field names.
+func (s *Client) ListEmailTemplates(ctx context.Context) (response ListEmailTemplatesResponse, err error) {
+	req, err := s.client.NewRequest("GET", "srs/list_email_templates.json", "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// GetEmailTemplateOptions identifies a single template to read.
+// Template is the template's name as returned by
+// ListEmailTemplates.
+type GetEmailTemplateOptions struct {
+	Template string `url:"template"`
+}
+
+// GetEmailTemplateResponse holds a single template body.
+type GetEmailTemplateResponse struct {
+	Return EmailTemplate `json:"return"`
+	models.APIResponse
+}
+
+// GetEmailTemplate returns a single email template via
+// "srs/get_email_templates.json" (GET). Note the docs spell the
+// path with the trailing 's' on "templates" even for a single-
+// template lookup.
+//
+// **Live finding (May 2026, gosh):** the `template` parameter is
+// validated as required ("The template name is missing." when
+// omitted) but no obvious value satisfies it. Probed against a
+// real account, none of the values surfaced by ListEmailTemplates
+// — the human-readable `name` ("Auto-Renew Reminder - 7 Days"),
+// the `type` slug ("AutoRenewReminder"), or the numeric
+// `template_id` ("11239") — were accepted; all returned "The
+// specified template doesn't exist, or you don't have access to
+// it." Use ListEmailTemplates to read template bodies in the
+// meantime; GetEmailTemplate is wrapped for completeness but is
+// effectively unusable until SiteHost clarifies the parameter
+// shape. See docs/api-issues/srs-get-email-template-shape.md.
+func (s *Client) GetEmailTemplate(ctx context.Context, opt GetEmailTemplateOptions) (response GetEmailTemplateResponse, err error) {
+	if opt.Template == "" {
+		return response, fmt.Errorf("srs.GetEmailTemplate: Template is required")
+	}
+	path, err := net.AddOptions("srs/get_email_templates.json", opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// UpdateEmailTemplateOptions edits a single template.
+//
+// Template is the template name (required). EmailSubject and
+// EmailTemplate are both optional — only set fields are sent. To
+// reset a template to its default, the SiteHost API does not
+// expose a dedicated "reset" verb; capture the defaults first via
+// GetEmailTemplate before editing if a rollback is needed.
+//
+// **Account-wide impact:** these templates drive customer-facing
+// renewal reminders, transfer notifications, etc. Test changes
+// against a non-production account first.
+type UpdateEmailTemplateOptions struct {
+	Template      string `url:"template"`
+	EmailSubject  string `url:"params[EmailSubject],omitempty"`
+	EmailTemplate string `url:"params[EmailTemplate],omitempty"`
+}
+
+// UpdateEmailTemplate edits an email template via
+// "srs/update_email_template.json" (POST).
+func (s *Client) UpdateEmailTemplate(ctx context.Context, opt UpdateEmailTemplateOptions) (response models.APIResponse, err error) {
+	if opt.Template == "" {
+		return response, fmt.Errorf("srs.UpdateEmailTemplate: Template is required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/update_email_template.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/email_templates.go
+++ b/pkg/api/srs/email_templates.go
@@ -29,7 +29,7 @@ type EmailTemplate struct {
 	DateUpdated   string   `json:"date_updated"`
 	AvailableTags []string `json:"available_tags"`
 	RequiredTags  []string `json:"required_tags"`
-	Customized    bool     `json:"customized"`
+	Customized    bool     `json:"customized"` //nolint:misspell // matches the upstream API JSON key
 }
 
 // ListEmailTemplatesResponse is the response from

--- a/pkg/api/srs/extras_test.go
+++ b/pkg/api/srs/extras_test.go
@@ -24,6 +24,7 @@ func mockSRS(t *testing.T, h http.HandlerFunc) (*api.Client, func()) {
 }
 
 func TestGetDomain_Success(t *testing.T) {
+	t.Parallel()
 	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/srs/get_domain.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -65,7 +66,8 @@ func TestGetDomain_Success(t *testing.T) {
 }
 
 func TestDomainAvailable_Success(t *testing.T) {
-	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+	t.Parallel()
+	c, done := mockSRS(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"status":true,"msg":"Available","return":true}`)
 	})
@@ -80,7 +82,8 @@ func TestDomainAvailable_Success(t *testing.T) {
 }
 
 func TestDomainInsideGracePeriod_Success(t *testing.T) {
-	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+	t.Parallel()
+	c, done := mockSRS(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"status":true,"msg":"Not in grace period","return":false}`)
 	})
@@ -95,7 +98,8 @@ func TestDomainInsideGracePeriod_Success(t *testing.T) {
 }
 
 func TestGetDomainPrice_Success(t *testing.T) {
-	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+	t.Parallel()
+	c, done := mockSRS(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"DomainPrice":39.5,"total_price":39.5,"tiered_price":"39.50","base_price":"39.50","premium":false,"base_privacy_price":"0.00","tiered_privacy_price":"0.00"}}`)
 	})
@@ -110,7 +114,8 @@ func TestGetDomainPrice_Success(t *testing.T) {
 }
 
 func TestCanTransferDomain_Success(t *testing.T) {
-	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+	t.Parallel()
+	c, done := mockSRS(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"domain":"example.nz","can_transfer":true,"reason":""}}`)
 	})
@@ -125,7 +130,8 @@ func TestCanTransferDomain_Success(t *testing.T) {
 }
 
 func TestListNameServers_Success(t *testing.T) {
-	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+	t.Parallel()
+	c, done := mockSRS(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":[
 			{"name":"ns1.sitehost.co.nz","ipv4addr":"","ipv6addr":""},
@@ -143,7 +149,8 @@ func TestListNameServers_Success(t *testing.T) {
 }
 
 func TestListContacts_Success(t *testing.T) {
-	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+	t.Parallel()
+	c, done := mockSRS(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
 			"total_items":1,"current_items":1,"current_page":1,"total_pages":1,
@@ -165,6 +172,7 @@ func TestListContacts_Success(t *testing.T) {
 }
 
 func TestGetContact_Success(t *testing.T) {
+	t.Parallel()
 	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Query().Get("contact_id"); got != "9001" {
 			t.Errorf("contact_id = %q", got)
@@ -186,6 +194,7 @@ func TestGetContact_Success(t *testing.T) {
 }
 
 func TestSearchContacts_FilterRequired(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	_, err := New(c).SearchContacts(context.Background(), SearchContactsOptions{})
 	if err == nil || !strings.Contains(err.Error(), "at least one of") {
@@ -194,7 +203,8 @@ func TestSearchContacts_FilterRequired(t *testing.T) {
 }
 
 func TestListValidTLDs_Success(t *testing.T) {
-	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+	t.Parallel()
+	c, done := mockSRS(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":[
 			{"tld":"co.nz","term":"12","type":"NZRS","can_transfer":"1","can_protect":"1","date_added":"","date_updated":""}
@@ -211,7 +221,8 @@ func TestListValidTLDs_Success(t *testing.T) {
 }
 
 func TestGetPricingTiers_Success(t *testing.T) {
-	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+	t.Parallel()
+	c, done := mockSRS(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":[
 			{"type":1,"type_name":"NZRS","count":"19","price":"39.50"}
@@ -228,7 +239,8 @@ func TestGetPricingTiers_Success(t *testing.T) {
 }
 
 func TestGetCompanyInfo_Success(t *testing.T) {
-	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+	t.Parallel()
+	c, done := mockSRS(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"client_id":1234,"companyname":"Test Co","companyurl":"https://test","companyrenewurl":"","companyemail":"","companyemailfrom":"","companyemailfromname":"","companysupportemail":"","companyphone":"","companyfax":"","send_renewed_email":"1","send_invoice":"1"}}`)
 	})
@@ -243,6 +255,7 @@ func TestGetCompanyInfo_Success(t *testing.T) {
 }
 
 func TestCreateDomain_RequiredFields(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	_, err := New(c).CreateDomain(context.Background(), CreateDomainOptions{Domain: "x.nz"})
 	if err == nil || !strings.Contains(err.Error(), "contact IDs") {
@@ -251,6 +264,7 @@ func TestCreateDomain_RequiredFields(t *testing.T) {
 }
 
 func TestCancelDomain_Success(t *testing.T) {
+	t.Parallel()
 	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/srs/cancel_domain.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -267,12 +281,13 @@ func TestCancelDomain_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CancelDomain: %v", err)
 	}
-	if got.Return.Job.ID != 29658613 {
-		t.Errorf("Job.ID = %d", got.Return.Job.ID)
+	if got.Return.ID != 29658613 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
 	}
 }
 
 func TestCreateDomain_Success(t *testing.T) {
+	t.Parallel()
 	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/srs/create_domain.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -299,7 +314,7 @@ func TestCreateDomain_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDomain: %v", err)
 	}
-	if got.Return.Job.ID != 29658610 {
-		t.Errorf("Job.ID = %d", got.Return.Job.ID)
+	if got.Return.ID != 29658610 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
 	}
 }

--- a/pkg/api/srs/extras_test.go
+++ b/pkg/api/srs/extras_test.go
@@ -1,0 +1,305 @@
+package srs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+// mockSRS spins up an httptest server and a client pointed at it.
+func mockSRS(t *testing.T, h http.HandlerFunc) (*api.Client, func()) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	c, err := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if err != nil {
+		srv.Close()
+		t.Fatalf("api.New: %v", err)
+	}
+	return c, srv.Close
+}
+
+func TestGetDomain_Success(t *testing.T) {
+	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/srs/get_domain.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("domain"); got != "example.nz" {
+			t.Errorf("domain = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true, "msg": "Successful.",
+			"return": {
+				"ClientID": 1234, "Domain": "example.nz", "State": "Active",
+				"RState": 0, "API": "IRS", "RegistrantName": "Alice",
+				"DateRegistered": "2015-12-16 11:37:19",
+				"DateBilledUntil": "2034-09-16 11:37:19",
+				"autorenew_term": 12, "autorenew_days_remaining": 60,
+				"RegistrantContactID": 9001, "AdminContactID": 9002,
+				"TechnicalContactID": 9003, "BillingContactID": 9004,
+				"Locked": false, "Private": false, "Pending": false,
+				"Premium": false
+			}
+		}`)
+	})
+	defer done()
+
+	got, err := New(c).GetDomain(context.Background(), DomainOptions{Domain: "example.nz"})
+	if err != nil {
+		t.Fatalf("GetDomain: %v", err)
+	}
+	if got.Return.Domain != "example.nz" {
+		t.Errorf("Domain = %q", got.Return.Domain)
+	}
+	if got.Return.AutorenewTerm != 12 {
+		t.Errorf("AutorenewTerm = %d", got.Return.AutorenewTerm)
+	}
+	if got.Return.Locked {
+		t.Errorf("Locked = true (real bool, not string)")
+	}
+}
+
+func TestDomainAvailable_Success(t *testing.T) {
+	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Available","return":true}`)
+	})
+	defer done()
+	got, err := New(c).DomainAvailable(context.Background(), DomainAvailableOptions{Domain: "fresh.nz"})
+	if err != nil {
+		t.Fatalf("DomainAvailable: %v", err)
+	}
+	if !got.Return {
+		t.Errorf("Return = false, want true")
+	}
+}
+
+func TestDomainInsideGracePeriod_Success(t *testing.T) {
+	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Not in grace period","return":false}`)
+	})
+	defer done()
+	got, err := New(c).DomainInsideGracePeriod(context.Background(), DomainOptions{Domain: "example.nz"})
+	if err != nil {
+		t.Fatalf("DomainInsideGracePeriod: %v", err)
+	}
+	if got.Return {
+		t.Errorf("Return = true, want false")
+	}
+}
+
+func TestGetDomainPrice_Success(t *testing.T) {
+	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"DomainPrice":39.5,"total_price":39.5,"tiered_price":"39.50","base_price":"39.50","premium":false,"base_privacy_price":"0.00","tiered_privacy_price":"0.00"}}`)
+	})
+	defer done()
+	got, err := New(c).GetDomainPrice(context.Background(), DomainOptions{Domain: "example.nz"})
+	if err != nil {
+		t.Fatalf("GetDomainPrice: %v", err)
+	}
+	if got.Return.DomainPrice != 39.5 {
+		t.Errorf("DomainPrice = %v", got.Return.DomainPrice)
+	}
+}
+
+func TestCanTransferDomain_Success(t *testing.T) {
+	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"domain":"example.nz","can_transfer":true,"reason":""}}`)
+	})
+	defer done()
+	got, err := New(c).CanTransferDomain(context.Background(), DomainOptions{Domain: "example.nz"})
+	if err != nil {
+		t.Fatalf("CanTransferDomain: %v", err)
+	}
+	if !got.Return.CanTransfer {
+		t.Errorf("CanTransfer = false")
+	}
+}
+
+func TestListNameServers_Success(t *testing.T) {
+	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":[
+			{"name":"ns1.sitehost.co.nz","ipv4addr":"","ipv6addr":""},
+			{"name":"ns2.sitehost.co.nz","ipv4addr":"","ipv6addr":""}
+		]}`)
+	})
+	defer done()
+	got, err := New(c).ListNameServers(context.Background(), DomainOptions{Domain: "example.nz"})
+	if err != nil {
+		t.Fatalf("ListNameServers: %v", err)
+	}
+	if len(got.Return) != 2 {
+		t.Fatalf("len(Return) = %d, want 2", len(got.Return))
+	}
+}
+
+func TestListContacts_Success(t *testing.T) {
+	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"total_items":1,"current_items":1,"current_page":1,"total_pages":1,
+			"status":true,"msg":"OK",
+			"return":[{"contact_id":"9001","name":"Alice","registrant_name":"Alice","email":"a@example.co.nz","phone_cntry":"64","phone_area":"09","phone_local":"1234567","phone_extension":"","domain_count":1}]
+		}`)
+	})
+	defer done()
+	got, err := New(c).ListContacts(context.Background())
+	if err != nil {
+		t.Fatalf("ListContacts: %v", err)
+	}
+	if len(got.Return) != 1 {
+		t.Fatalf("len(Return) = %d, want 1", len(got.Return))
+	}
+	if got.Return[0].DomainCount != 1 {
+		t.Errorf("DomainCount = %d", got.Return[0].DomainCount)
+	}
+}
+
+func TestGetContact_Success(t *testing.T) {
+	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("contact_id"); got != "9001" {
+			t.Errorf("contact_id = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status":true,"msg":"OK",
+			"return":{"ContactID":9001,"ClientID":"1234","Name":"Alice","RegistrantName":"Alice","Country":"NZ"}
+		}`)
+	})
+	defer done()
+	got, err := New(c).GetContact(context.Background(), ContactOptions{ContactID: "9001"})
+	if err != nil {
+		t.Fatalf("GetContact: %v", err)
+	}
+	if got.Return.Country != "NZ" {
+		t.Errorf("Country = %q", got.Return.Country)
+	}
+}
+
+func TestSearchContacts_FilterRequired(t *testing.T) {
+	c, _ := api.New("k", "1")
+	_, err := New(c).SearchContacts(context.Background(), SearchContactsOptions{})
+	if err == nil || !strings.Contains(err.Error(), "at least one of") {
+		t.Errorf("expected filter required, got: %v", err)
+	}
+}
+
+func TestListValidTLDs_Success(t *testing.T) {
+	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":[
+			{"tld":"co.nz","term":"12","type":"NZRS","can_transfer":"1","can_protect":"1","date_added":"","date_updated":""}
+		]}`)
+	})
+	defer done()
+	got, err := New(c).ListValidTLDs(context.Background())
+	if err != nil {
+		t.Fatalf("ListValidTLDs: %v", err)
+	}
+	if got.Return[0].TLD != "co.nz" {
+		t.Errorf("TLD = %q", got.Return[0].TLD)
+	}
+}
+
+func TestGetPricingTiers_Success(t *testing.T) {
+	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":[
+			{"type":1,"type_name":"NZRS","count":"19","price":"39.50"}
+		]}`)
+	})
+	defer done()
+	got, err := New(c).GetPricingTiers(context.Background())
+	if err != nil {
+		t.Fatalf("GetPricingTiers: %v", err)
+	}
+	if got.Return[0].Price != "39.50" {
+		t.Errorf("Price = %q", got.Return[0].Price)
+	}
+}
+
+func TestGetCompanyInfo_Success(t *testing.T) {
+	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"client_id":1234,"companyname":"Test Co","companyurl":"https://test","companyrenewurl":"","companyemail":"","companyemailfrom":"","companyemailfromname":"","companysupportemail":"","companyphone":"","companyfax":"","send_renewed_email":"1","send_invoice":"1"}}`)
+	})
+	defer done()
+	got, err := New(c).GetCompanyInfo(context.Background())
+	if err != nil {
+		t.Fatalf("GetCompanyInfo: %v", err)
+	}
+	if got.Return.CompanyName != "Test Co" {
+		t.Errorf("CompanyName = %q", got.Return.CompanyName)
+	}
+}
+
+func TestCreateDomain_RequiredFields(t *testing.T) {
+	c, _ := api.New("k", "1")
+	_, err := New(c).CreateDomain(context.Background(), CreateDomainOptions{Domain: "x.nz"})
+	if err == nil || !strings.Contains(err.Error(), "contact IDs") {
+		t.Errorf("expected contact IDs required, got: %v", err)
+	}
+}
+
+func TestCancelDomain_Success(t *testing.T) {
+	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/srs/cancel_domain.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = r.ParseForm()
+		if got := r.Form.Get("domain"); got != "x.nz" {
+			t.Errorf("domain = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":29658613,"type":"scheduler"}}}`)
+	})
+	defer done()
+	got, err := New(c).CancelDomain(context.Background(), DomainOptions{Domain: "x.nz"})
+	if err != nil {
+		t.Fatalf("CancelDomain: %v", err)
+	}
+	if got.Return.Job.ID != 29658613 {
+		t.Errorf("Job.ID = %d", got.Return.Job.ID)
+	}
+}
+
+func TestCreateDomain_Success(t *testing.T) {
+	c, done := mockSRS(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/srs/create_domain.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = r.ParseForm()
+		if got := r.Form.Get("registrant_contact"); got != "9001" {
+			t.Errorf("registrant_contact = %q (note: not registrant_contact_id)", got)
+		}
+		if got := r.Form.Get("params[AdminContact]"); got != "9002" {
+			t.Errorf("params[AdminContact] = %q (note: PascalCase nested)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":29658610,"type":"scheduler"}}}`)
+	})
+	defer done()
+	got, err := New(c).CreateDomain(context.Background(), CreateDomainOptions{
+		Domain:            "fresh.nz",
+		Term:              12,
+		RegistrantContact: 9001,
+		AdminContact:      9002,
+		TechnicalContact:  9003,
+		BillingContact:    9004,
+	})
+	if err != nil {
+		t.Fatalf("CreateDomain: %v", err)
+	}
+	if got.Return.Job.ID != 29658610 {
+		t.Errorf("Job.ID = %d", got.Return.Job.ID)
+	}
+}

--- a/pkg/api/srs/extras_test.go
+++ b/pkg/api/srs/extras_test.go
@@ -193,6 +193,39 @@ func TestGetContact_Success(t *testing.T) {
 	}
 }
 
+// TestListContacts_DomainCountString locks down the polymorphic
+// domain_count quirk: established contacts return it as a JSON
+// number, newly-created contacts return it as a JSON string. Both
+// must decode without error.
+func TestListContacts_DomainCountString(t *testing.T) {
+	t.Parallel()
+	c, done := mockSRS(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"total_items":2,"current_items":2,"current_page":1,"total_pages":1,
+			"status":true,"msg":"OK",
+			"return":[
+				{"contact_id":"9001","name":"Established","registrant_name":"E","email":"e@example.co.nz","phone_cntry":"64","phone_area":"09","phone_local":"1234567","phone_extension":"","domain_count":7},
+				{"contact_id":"9002","name":"Newly Created","registrant_name":"N","email":"n@example.co.nz","phone_cntry":"64","phone_area":"09","phone_local":"7654321","phone_extension":"","domain_count":"0"}
+			]
+		}`)
+	})
+	defer done()
+	got, err := New(c).ListContacts(context.Background())
+	if err != nil {
+		t.Fatalf("ListContacts: %v", err)
+	}
+	if len(got.Return) != 2 {
+		t.Fatalf("len(Return) = %d, want 2", len(got.Return))
+	}
+	if got.Return[0].DomainCount != 7 {
+		t.Errorf("Return[0].DomainCount = %d, want 7", got.Return[0].DomainCount)
+	}
+	if got.Return[1].DomainCount != 0 {
+		t.Errorf("Return[1].DomainCount = %d, want 0 (string-form)", got.Return[1].DomainCount)
+	}
+}
+
 func TestSearchContacts_FilterRequired(t *testing.T) {
 	t.Parallel()
 	c, _ := api.New("k", "1")

--- a/pkg/api/srs/getdomain.go
+++ b/pkg/api/srs/getdomain.go
@@ -1,0 +1,129 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// GetDomain returns the full record for a domain via
+// "srs/get_domain.json". Domain is required.
+func (s *Client) GetDomain(ctx context.Context, opt DomainOptions) (response GetDomainResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.GetDomain: Domain is required")
+	}
+	path, err := net.AddOptions("srs/get_domain.json", opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// DomainAvailable reports whether a domain is registrable via
+// "srs/domain_available.json". Domain is required.
+func (s *Client) DomainAvailable(ctx context.Context, opt DomainAvailableOptions) (response BoolResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.DomainAvailable: Domain is required")
+	}
+	path, err := net.AddOptions("srs/domain_available.json", opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// DomainInsideGracePeriod reports whether a domain is in the
+// post-cancellation grace period via
+// "srs/domain_inside_grace_period.json". Domain is required.
+func (s *Client) DomainInsideGracePeriod(ctx context.Context, opt DomainOptions) (response BoolResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.DomainInsideGracePeriod: Domain is required")
+	}
+	path, err := net.AddOptions("srs/domain_inside_grace_period.json", opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// GetDomainPrice returns pricing for a domain via
+// "srs/get_domain_price.json". Domain is required.
+func (s *Client) GetDomainPrice(ctx context.Context, opt DomainOptions) (response GetDomainPriceResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.GetDomainPrice: Domain is required")
+	}
+	path, err := net.AddOptions("srs/get_domain_price.json", opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// CanTransferDomain reports whether a domain can be transferred
+// in via "srs/can_transfer_domain.json". Domain is required.
+func (s *Client) CanTransferDomain(ctx context.Context, opt DomainOptions) (response CanTransferDomainResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.CanTransferDomain: Domain is required")
+	}
+	path, err := net.AddOptions("srs/can_transfer_domain.json", opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// ListNameServers returns the nameserver delegation for a
+// domain via "srs/list_name_servers.json". Domain is required.
+func (s *Client) ListNameServers(ctx context.Context, opt DomainOptions) (response ListNameServersResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.ListNameServers: Domain is required")
+	}
+	path, err := net.AddOptions("srs/list_name_servers.json", opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/inspection.go
+++ b/pkg/api/srs/inspection.go
@@ -1,0 +1,45 @@
+package srs
+
+import (
+	"context"
+)
+
+// ListValidTLDs returns the list of TLDs the client may
+// register via "srs/list_valid_tlds.json".
+func (s *Client) ListValidTLDs(ctx context.Context) (response ListValidTLDsResponse, err error) {
+	req, err := s.client.NewRequest("GET", "srs/list_valid_tlds.json", "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// GetPricingTiers returns the count→price tier map for domain
+// registrations via "srs/get_pricing_tiers.json".
+func (s *Client) GetPricingTiers(ctx context.Context) (response GetPricingTiersResponse, err error) {
+	req, err := s.client.NewRequest("GET", "srs/get_pricing_tiers.json", "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// GetCompanyInfo returns the client's company profile (used in
+// renewal emails and registry contacts) via
+// "srs/get_company_info.json".
+func (s *Client) GetCompanyInfo(ctx context.Context) (response GetCompanyInfoResponse, err error) {
+	req, err := s.client.NewRequest("GET", "srs/get_company_info.json", "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/lifecycle.go
+++ b/pkg/api/srs/lifecycle.go
@@ -1,0 +1,69 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+)
+
+// CreateDomain registers a new domain via
+// "srs/create_domain.json". Domain and all four contact IDs
+// (RegistrantContact, AdminContact, TechnicalContact,
+// BillingContact) are required.
+//
+// **This is destructive.** Successful registration incurs a real
+// registry charge. For .nz domains, registrations cancelled
+// within 5 days of creation are not billed (per registry
+// grace-period rules); other TLDs vary. The account must hold
+// sufficient funds at registration time regardless.
+//
+// Returns a JobResponse with the scheduler job ID for tracking
+// the asynchronous registration.
+func (s *Client) CreateDomain(ctx context.Context, opt CreateDomainOptions) (response JobResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.CreateDomain: Domain is required")
+	}
+	if opt.RegistrantContact == 0 || opt.AdminContact == 0 ||
+		opt.TechnicalContact == 0 || opt.BillingContact == 0 {
+		return response, fmt.Errorf("srs.CreateDomain: all four contact IDs (RegistrantContact, AdminContact, TechnicalContact, BillingContact) are required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/create_domain.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// CancelDomain cancels a domain registration via
+// "srs/cancel_domain.json". Domain is required. Returns a
+// JobResponse with the scheduler job ID for tracking the
+// asynchronous cancellation.
+//
+// For .nz domains cancelled within 5 days of registration, no
+// billing is incurred. Outside that window, billing rules apply
+// per the registry.
+func (s *Client) CancelDomain(ctx context.Context, opt DomainOptions) (response JobResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.CancelDomain: Domain is required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/cancel_domain.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/list_test.go
+++ b/pkg/api/srs/list_test.go
@@ -1,0 +1,130 @@
+package srs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestListDomains_Success(t *testing.T) {
+	const (
+		apiKey   = "test-key"
+		clientID = "1234"
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/srs/list_domains.json" {
+			t.Errorf("path = %q, want /srs/list_domains.json", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"return": {
+				"current_items": 2,
+				"current_page": 1,
+				"total_pages": 1,
+				"total_items": 2,
+				"data": [
+					{
+						"domain_id": "100", "domain": "example.co.nz", "state": "Active", "api": "IRS",
+						"client_id": "1234", "client_name": "Test",
+						"locked": "0", "private": "0", "pending": "0", "premium": "0",
+						"registrant_name": "Alice", "reg_id": "10", "reg_name": "Alice",
+						"adm_id": "11", "adm_name": "Alice", "tec_id": "12", "tec_name": "Alice",
+						"autorenew_term": "12", "autorenew_days_remaining": "60",
+						"dateregistered":  "2025-01-01 00:00:00", "datemodified": "2025-01-02 00:00:00",
+						"datebilleduntil": "2026-01-01 00:00:00",
+						"datecancelled":   "0000-00-00 00:00:00", "datelocked": "0000-00-00 00:00:00"
+					},
+					{
+						"domain_id": "101", "domain": "another.nz", "state": "Active", "api": "IRS",
+						"client_id": "1234", "client_name": "Test",
+						"locked": "0", "private": "0", "pending": "0", "premium": "0",
+						"registrant_name": "Bob", "reg_id": "20", "reg_name": "Bob",
+						"adm_id": "21", "adm_name": "Bob", "tec_id": "22", "tec_name": "Bob",
+						"autorenew_term": "12", "autorenew_days_remaining": "30",
+						"dateregistered":  "2024-06-01 00:00:00", "datemodified": "2024-06-02 00:00:00",
+						"datebilleduntil": "2026-06-01 00:00:00",
+						"datecancelled":   "0000-00-00 00:00:00", "datelocked": "0000-00-00 00:00:00"
+					}
+				]
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New(apiKey, clientID, api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).ListDomains(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListDomains: %v", err)
+	}
+
+	if !got.Status {
+		t.Errorf("Status = false, want true")
+	}
+	if len(got.Return.Data) != 2 {
+		t.Fatalf("len(Data) = %d, want 2", len(got.Return.Data))
+	}
+	if got.Return.Data[0].Domain != "example.co.nz" {
+		t.Errorf("Data[0].Domain = %q, want example.co.nz", got.Return.Data[0].Domain)
+	}
+	if got.Return.Data[0].ID != "100" {
+		t.Errorf("Data[0].ID = %q, want 100", got.Return.Data[0].ID)
+	}
+	if got.Return.Data[0].ClientID != "1234" {
+		t.Errorf("Data[0].ClientID = %q, want 1234", got.Return.Data[0].ClientID)
+	}
+	if got.Return.Data[0].RegistrantName != "Alice" {
+		t.Errorf("Data[0].RegistrantName = %q, want Alice", got.Return.Data[0].RegistrantName)
+	}
+	if got.Return.Data[0].AutoRenewTerm != "12" {
+		t.Errorf("Data[0].AutoRenewTerm = %q, want 12", got.Return.Data[0].AutoRenewTerm)
+	}
+	if got.Return.Data[0].Locked != "0" {
+		t.Errorf("Data[0].Locked = %q, want 0", got.Return.Data[0].Locked)
+	}
+}
+
+func TestListDomains_FilterParams(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if got := q.Get("filters[sort_by]"); got != "domain" {
+			t.Errorf("filters[sort_by] = %q, want domain", got)
+		}
+		if got := q.Get("filters[sort_dir]"); got != "asc" {
+			t.Errorf("filters[sort_dir] = %q, want asc", got)
+		}
+		if got := q.Get("filters[page_size]"); got != "50" {
+			t.Errorf("filters[page_size] = %q, want 50", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"data":[]}}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	_, err = New(c).ListDomains(context.Background(), &ListDomainsOptions{
+		SortBy:   "domain",
+		SortDir:  "asc",
+		PageSize: 50,
+	})
+	if err != nil {
+		t.Fatalf("ListDomains: %v", err)
+	}
+}

--- a/pkg/api/srs/list_test.go
+++ b/pkg/api/srs/list_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/sitehostnz/gosh/pkg/api"
 )
 
+const testCoNZDomain = "example.co.nz"
+
 func TestListDomains_Success(t *testing.T) {
+	t.Parallel()
 	const (
 		apiKey   = "test-key"
 		clientID = "1234"
@@ -77,8 +80,8 @@ func TestListDomains_Success(t *testing.T) {
 	if len(got.Return.Data) != 2 {
 		t.Fatalf("len(Data) = %d, want 2", len(got.Return.Data))
 	}
-	if got.Return.Data[0].Domain != "example.co.nz" {
-		t.Errorf("Data[0].Domain = %q, want example.co.nz", got.Return.Data[0].Domain)
+	if got.Return.Data[0].Domain != testCoNZDomain {
+		t.Errorf("Data[0].Domain = %q, want %s", got.Return.Data[0].Domain, testCoNZDomain)
 	}
 	if got.Return.Data[0].ID != "100" {
 		t.Errorf("Data[0].ID = %q, want 100", got.Return.Data[0].ID)
@@ -98,6 +101,7 @@ func TestListDomains_Success(t *testing.T) {
 }
 
 func TestListDomains_FilterParams(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		if got := q.Get("filters[sort_by]"); got != "domain" {

--- a/pkg/api/srs/listdomains.go
+++ b/pkg/api/srs/listdomains.go
@@ -1,0 +1,37 @@
+package srs
+
+import (
+	"context"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// ListDomains retrieves the list of domains registered for the
+// authenticated client via "srs/list_domains.json".
+//
+// opt may be nil (returns the default page with default sort);
+// otherwise SortBy / SortDir / PageSize / PageNumber narrow or
+// reorder the result.
+//
+// The endpoint is documented at https://docs.sitehost.nz/api/v1.5/?path=/srs.
+// The per-endpoint reference page is sparse at the time of writing —
+// field shapes here mirror the production API's responses.
+func (s *Client) ListDomains(ctx context.Context, opt *ListDomainsOptions) (response ListDomainsResponse, err error) {
+	u := "srs/list_domains.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/srs/locks.go
+++ b/pkg/api/srs/locks.go
@@ -1,0 +1,65 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// LockDomain places a transfer lock on a domain via
+// "srs/lock_domain.json". Lock prevents transfer-out attempts at
+// the registry until the domain is unlocked. Synchronous; the
+// response is a bare {status, msg} envelope (no scheduler job).
+//
+// **TLD-policy gotcha (verified live):** **.nz domains reject this
+// call** with "This domain cannot be locked." The .nz registry
+// uses the UDAI (transfer authorisation code) model rather than
+// EPP-style transfer locks, so transfer protection is achieved by
+// withholding the UDAI rather than by locking. Other gTLDs (.com,
+// .net, etc.) honour the lock as expected.
+//
+// Verify the new state via srs.GetDomain(domain).DateLocked
+// (empty / zero-date when unlocked).
+func (s *Client) LockDomain(ctx context.Context, opt DomainOptions) (response models.APIResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.LockDomain: Domain is required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/lock_domain.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// UnlockDomain releases the transfer lock on a domain via
+// "srs/unlock_domain.json". Same shape as LockDomain — bare
+// {status, msg} envelope, idempotent.
+//
+// Same .nz caveat applies: .nz registry policy rejects the call
+// (UDAI model, not lock-based transfer auth). See LockDomain.
+func (s *Client) UnlockDomain(ctx context.Context, opt DomainOptions) (response models.APIResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.UnlockDomain: Domain is required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/unlock_domain.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/models.go
+++ b/pkg/api/srs/models.go
@@ -1,0 +1,19 @@
+package srs
+
+import (
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+type (
+	// Client is a Service to work with the SiteHost SRS API.
+	Client struct {
+		client *api.Client
+	}
+)
+
+// New is an initialisation function.
+func New(c *api.Client) *Client {
+	return &Client{
+		client: c,
+	}
+}

--- a/pkg/api/srs/nameserverresponse.go
+++ b/pkg/api/srs/nameserverresponse.go
@@ -5,7 +5,7 @@ import "github.com/sitehostnz/gosh/pkg/models"
 type (
 	// NameServer is a single nameserver entry.
 	NameServer struct {
-		Name    string `json:"name"`
+		Name     string `json:"name"`
 		IPv4Addr string `json:"ipv4addr"`
 		IPv6Addr string `json:"ipv6addr"`
 	}

--- a/pkg/api/srs/nameserverresponse.go
+++ b/pkg/api/srs/nameserverresponse.go
@@ -1,0 +1,19 @@
+package srs
+
+import "github.com/sitehostnz/gosh/pkg/models"
+
+type (
+	// NameServer is a single nameserver entry.
+	NameServer struct {
+		Name    string `json:"name"`
+		IPv4Addr string `json:"ipv4addr"`
+		IPv6Addr string `json:"ipv6addr"`
+	}
+
+	// ListNameServersResponse represents the response from
+	// list_name_servers.
+	ListNameServersResponse struct {
+		Return []NameServer `json:"return"`
+		models.APIResponse
+	}
+)

--- a/pkg/api/srs/nameservers_add.go
+++ b/pkg/api/srs/nameservers_add.go
@@ -1,0 +1,74 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// NameServerEntry is a single nameserver record to add to a domain
+// via "srs/add_name_servers.json". Name is required; IPv4Addr and
+// IPv6Addr are only required when registering glue records (the
+// nameserver is itself a hostname inside the domain you're
+// updating). For external nameservers (ns1.somewhere-else.com)
+// leave IPv4Addr and IPv6Addr empty.
+type NameServerEntry struct {
+	Name     string
+	IPv4Addr string
+	IPv6Addr string
+}
+
+// AddNameServersOptions adds one or more nameservers to a domain.
+// Domain and at least one entry in NameServers are required.
+//
+// The wire format is array-indexed:
+//
+//	nameservers[0][name]=ns1.example.com
+//	nameservers[0][ipv4addr]=192.0.2.1     (optional, glue only)
+//	nameservers[1][name]=ns2.example.com
+//	...
+//
+// Add is additive — existing nameservers are preserved unless the
+// registry replaces them. To replace the full set, you typically
+// remove (registry-side; not currently exposed) and re-add.
+type AddNameServersOptions struct {
+	Domain      string
+	NameServers []NameServerEntry
+}
+
+// AddNameServers attaches one or more nameservers to a domain via
+// "srs/add_name_servers.json".
+func (s *Client) AddNameServers(ctx context.Context, opt AddNameServersOptions) (response models.APIResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.AddNameServers: Domain is required")
+	}
+	if len(opt.NameServers) == 0 {
+		return response, fmt.Errorf("srs.AddNameServers: at least one NameServer is required")
+	}
+	values := url.Values{}
+	values.Set("domain", opt.Domain)
+	for i, ns := range opt.NameServers {
+		if ns.Name == "" {
+			return response, fmt.Errorf("srs.AddNameServers: NameServers[%d].Name is required", i)
+		}
+		idx := strconv.Itoa(i)
+		values.Set("nameservers["+idx+"][name]", ns.Name)
+		if ns.IPv4Addr != "" {
+			values.Set("nameservers["+idx+"][ipv4addr]", ns.IPv4Addr)
+		}
+		if ns.IPv6Addr != "" {
+			values.Set("nameservers["+idx+"][ipv6addr]", ns.IPv6Addr)
+		}
+	}
+	req, err := s.client.NewRequest("POST", "srs/add_name_servers.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/number.go
+++ b/pkg/api/srs/number.go
@@ -1,0 +1,31 @@
+package srs
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// Number tolerates the SRS API's mixed JSON-string / JSON-number
+// serialisation of numeric fields. ContactSummary.DomainCount is
+// the known case: established contacts return it as a JSON number
+// (`0`), newly-created contacts return it as a JSON string (`"0"`),
+// within the same shape. Mirrors the bandwidth.Number pattern from
+// PR #43.
+type Number int64
+
+// UnmarshalJSON accepts either a JSON string or JSON number.
+func (n *Number) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return err
+		}
+		*n = Number(v)
+		return nil
+	}
+	return json.Unmarshal(b, (*int64)(n))
+}

--- a/pkg/api/srs/privacy.go
+++ b/pkg/api/srs/privacy.go
@@ -1,0 +1,68 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// PrivacyOptions describes a privacy-protection toggle. Reason is
+// required by the API for both enable and disable; it's recorded
+// at the registrar but is not user-visible.
+type PrivacyOptions struct {
+	Domain string `url:"domain"`
+	Reason string `url:"reason"`
+}
+
+// EnablePrivacyProtection enables WHOIS privacy on a domain via
+// "srs/enable_privacy_protection.json". Reason is required by the
+// API even though the field has no externally-visible effect.
+//
+// Verify the new state via srs.GetDomain(domain).Private
+// (returned as "1" / "0" string).
+func (s *Client) EnablePrivacyProtection(ctx context.Context, opt PrivacyOptions) (response models.APIResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.EnablePrivacyProtection: Domain is required")
+	}
+	if opt.Reason == "" {
+		return response, fmt.Errorf("srs.EnablePrivacyProtection: Reason is required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/enable_privacy_protection.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// DisablePrivacyProtection turns WHOIS privacy off via
+// "srs/disable_privacy_protection.json". Same Reason-required
+// shape as EnablePrivacyProtection.
+func (s *Client) DisablePrivacyProtection(ctx context.Context, opt PrivacyOptions) (response models.APIResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.DisablePrivacyProtection: Domain is required")
+	}
+	if opt.Reason == "" {
+		return response, fmt.Errorf("srs.DisablePrivacyProtection: Reason is required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/disable_privacy_protection.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/renew_domain.go
+++ b/pkg/api/srs/renew_domain.go
@@ -1,0 +1,53 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// RenewDomainOptions extends a domain's registration term.
+//
+// **This call charges the SiteHost account** at the renewal price
+// for Term months — same pricing matrix as srs.GetDomainPrice with
+// type="renew". There is no dry-run mode. Read GetDomain.BilledUntil
+// before and after to confirm the extension landed.
+//
+// Term is the renewal length in months (12 = 1 year, 24 = 2 years).
+// Privacy is optional: 1 enables WHOIS privacy at renewal time, 0
+// disables. Leave empty to keep the current setting.
+type RenewDomainOptions struct {
+	Domain  string `url:"domain"`
+	Term    int    `url:"term"`
+	Privacy string `url:"options[privacy],omitempty"`
+}
+
+// RenewDomain extends a domain's registration via
+// "srs/renew_domain.json". Returns the bare {status, msg} envelope;
+// the registry update is synchronous.
+//
+// **Cost warning:** this charges the account. Avoid in tests
+// against billed test domains unless you've confirmed cost is
+// acceptable.
+func (s *Client) RenewDomain(ctx context.Context, opt RenewDomainOptions) (response models.APIResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.RenewDomain: Domain is required")
+	}
+	if opt.Term <= 0 {
+		return response, fmt.Errorf("srs.RenewDomain: Term must be > 0 months")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/renew_domain.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/tier1_writes_test.go
+++ b/pkg/api/srs/tier1_writes_test.go
@@ -1,0 +1,158 @@
+package srs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func formBody(t *testing.T, r *http.Request) url.Values {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	v, err := url.ParseQuery(string(body))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return v
+}
+
+func TestLockDomain_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/srs/lock_domain.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := formBody(t, r)
+		if v.Get("domain") != "example.com" {
+			t.Errorf("domain = %q", v.Get("domain"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Domain locked."}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).LockDomain(context.Background(), DomainOptions{Domain: "example.com"}); err != nil {
+		t.Fatalf("LockDomain: %v", err)
+	}
+}
+
+func TestLockDomain_RequiresDomain(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	if _, err := New(c).LockDomain(context.Background(), DomainOptions{}); err == nil {
+		t.Fatal("expected error for missing Domain")
+	}
+}
+
+func TestUnlockDomain_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/srs/unlock_domain.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Domain unlocked."}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).UnlockDomain(context.Background(), DomainOptions{Domain: "example.com"}); err != nil {
+		t.Fatalf("UnlockDomain: %v", err)
+	}
+}
+
+func TestEnablePrivacyProtection_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/srs/enable_privacy_protection.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := formBody(t, r)
+		if v.Get("reason") != "test run" {
+			t.Errorf("reason = %q", v.Get("reason"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Privacy enabled."}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).EnablePrivacyProtection(context.Background(), PrivacyOptions{
+		Domain: "example.com", Reason: "test run",
+	}); err != nil {
+		t.Fatalf("EnablePrivacyProtection: %v", err)
+	}
+}
+
+func TestEnablePrivacyProtection_RequiresReason(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	if _, err := New(c).EnablePrivacyProtection(context.Background(), PrivacyOptions{
+		Domain: "example.com",
+	}); err == nil {
+		t.Fatal("expected error for missing Reason")
+	}
+}
+
+func TestDisablePrivacyProtection_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/srs/disable_privacy_protection.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Privacy disabled."}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).DisablePrivacyProtection(context.Background(), PrivacyOptions{
+		Domain: "example.com", Reason: "test run",
+	}); err != nil {
+		t.Fatalf("DisablePrivacyProtection: %v", err)
+	}
+}
+
+func TestUpdateAutoRenew_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/srs/update_auto_renew.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := formBody(t, r)
+		if v.Get("term") != "12" || v.Get("days_remaining") != "30" {
+			t.Errorf("body = %v", v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Auto-renew updated."}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).UpdateAutoRenew(context.Background(), UpdateAutoRenewOptions{
+		Domain: "example.com", Term: 12, DaysRemaining: 30,
+	}); err != nil {
+		t.Fatalf("UpdateAutoRenew: %v", err)
+	}
+}
+
+func TestUpdateAutoRenew_DisableViaTermZero(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := formBody(t, r)
+		if v.Get("term") != "0" {
+			t.Errorf("term = %q (want 0 for disable)", v.Get("term"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Auto-renew disabled."}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).UpdateAutoRenew(context.Background(), UpdateAutoRenewOptions{
+		Domain: "example.com", Term: 0, DaysRemaining: 30,
+	}); err != nil {
+		t.Fatalf("UpdateAutoRenew: %v", err)
+	}
+}

--- a/pkg/api/srs/tier1_writes_test.go
+++ b/pkg/api/srs/tier1_writes_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/sitehostnz/gosh/pkg/api"
 )
 
+const testComDomain = "example.com"
+
 func formBody(t *testing.T, r *http.Request) url.Values {
 	t.Helper()
 	body, err := io.ReadAll(r.Body)
@@ -25,12 +27,13 @@ func formBody(t *testing.T, r *http.Request) url.Values {
 }
 
 func TestLockDomain_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/srs/lock_domain.json" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		v := formBody(t, r)
-		if v.Get("domain") != "example.com" {
+		if v.Get("domain") != testComDomain {
 			t.Errorf("domain = %q", v.Get("domain"))
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -39,12 +42,13 @@ func TestLockDomain_Success(t *testing.T) {
 	defer srv.Close()
 
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
-	if _, err := New(c).LockDomain(context.Background(), DomainOptions{Domain: "example.com"}); err != nil {
+	if _, err := New(c).LockDomain(context.Background(), DomainOptions{Domain: testComDomain}); err != nil {
 		t.Fatalf("LockDomain: %v", err)
 	}
 }
 
 func TestLockDomain_RequiresDomain(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
 	if _, err := New(c).LockDomain(context.Background(), DomainOptions{}); err == nil {
 		t.Fatal("expected error for missing Domain")
@@ -52,6 +56,7 @@ func TestLockDomain_RequiresDomain(t *testing.T) {
 }
 
 func TestUnlockDomain_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/srs/unlock_domain.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -62,12 +67,13 @@ func TestUnlockDomain_Success(t *testing.T) {
 	defer srv.Close()
 
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
-	if _, err := New(c).UnlockDomain(context.Background(), DomainOptions{Domain: "example.com"}); err != nil {
+	if _, err := New(c).UnlockDomain(context.Background(), DomainOptions{Domain: testComDomain}); err != nil {
 		t.Fatalf("UnlockDomain: %v", err)
 	}
 }
 
 func TestEnablePrivacyProtection_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/srs/enable_privacy_protection.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -83,22 +89,24 @@ func TestEnablePrivacyProtection_Success(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
 	if _, err := New(c).EnablePrivacyProtection(context.Background(), PrivacyOptions{
-		Domain: "example.com", Reason: "test run",
+		Domain: testComDomain, Reason: "test run",
 	}); err != nil {
 		t.Fatalf("EnablePrivacyProtection: %v", err)
 	}
 }
 
 func TestEnablePrivacyProtection_RequiresReason(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
 	if _, err := New(c).EnablePrivacyProtection(context.Background(), PrivacyOptions{
-		Domain: "example.com",
+		Domain: testComDomain,
 	}); err == nil {
 		t.Fatal("expected error for missing Reason")
 	}
 }
 
 func TestDisablePrivacyProtection_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/srs/disable_privacy_protection.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -110,13 +118,14 @@ func TestDisablePrivacyProtection_Success(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
 	if _, err := New(c).DisablePrivacyProtection(context.Background(), PrivacyOptions{
-		Domain: "example.com", Reason: "test run",
+		Domain: testComDomain, Reason: "test run",
 	}); err != nil {
 		t.Fatalf("DisablePrivacyProtection: %v", err)
 	}
 }
 
 func TestUpdateAutoRenew_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/srs/update_auto_renew.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -132,13 +141,14 @@ func TestUpdateAutoRenew_Success(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
 	if _, err := New(c).UpdateAutoRenew(context.Background(), UpdateAutoRenewOptions{
-		Domain: "example.com", Term: 12, DaysRemaining: 30,
+		Domain: testComDomain, Term: 12, DaysRemaining: 30,
 	}); err != nil {
 		t.Fatalf("UpdateAutoRenew: %v", err)
 	}
 }
 
 func TestUpdateAutoRenew_DisableViaTermZero(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v := formBody(t, r)
 		if v.Get("term") != "0" {
@@ -151,7 +161,7 @@ func TestUpdateAutoRenew_DisableViaTermZero(t *testing.T) {
 
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
 	if _, err := New(c).UpdateAutoRenew(context.Background(), UpdateAutoRenewOptions{
-		Domain: "example.com", Term: 0, DaysRemaining: 30,
+		Domain: testComDomain, Term: 0, DaysRemaining: 30,
 	}); err != nil {
 		t.Fatalf("UpdateAutoRenew: %v", err)
 	}

--- a/pkg/api/srs/tier3_5_writes_test.go
+++ b/pkg/api/srs/tier3_5_writes_test.go
@@ -10,15 +10,18 @@ import (
 	"github.com/sitehostnz/gosh/pkg/api"
 )
 
+const testTemplate = "renewal"
+
 // ---------------- Tier 3: domain mutators ----------------
 
 func TestAddNameServers_EncodesArray(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/srs/add_name_servers.json" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		v := formBody(t, r)
-		if v.Get("domain") != "example.com" ||
+		if v.Get("domain") != testComDomain ||
 			v.Get("nameservers[0][name]") != "ns1.example.com" ||
 			v.Get("nameservers[1][name]") != "ns2.example.com" ||
 			v.Get("nameservers[0][ipv4addr]") != "192.0.2.1" {
@@ -30,7 +33,7 @@ func TestAddNameServers_EncodesArray(t *testing.T) {
 	defer srv.Close()
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
 	if _, err := New(c).AddNameServers(context.Background(), AddNameServersOptions{
-		Domain: "example.com",
+		Domain: testComDomain,
 		NameServers: []NameServerEntry{
 			{Name: "ns1.example.com", IPv4Addr: "192.0.2.1"},
 			{Name: "ns2.example.com"},
@@ -41,20 +44,23 @@ func TestAddNameServers_EncodesArray(t *testing.T) {
 }
 
 func TestAddNameServers_RequiresAtLeastOne(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
-	if _, err := New(c).AddNameServers(context.Background(), AddNameServersOptions{Domain: "example.com"}); err == nil {
+	if _, err := New(c).AddNameServers(context.Background(), AddNameServersOptions{Domain: testComDomain}); err == nil {
 		t.Fatal("expected error for empty NameServers")
 	}
 }
 
 func TestRenewDomain_RequiresTerm(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
-	if _, err := New(c).RenewDomain(context.Background(), RenewDomainOptions{Domain: "example.com"}); err == nil {
+	if _, err := New(c).RenewDomain(context.Background(), RenewDomainOptions{Domain: testComDomain}); err == nil {
 		t.Fatal("expected error for Term=0")
 	}
 }
 
 func TestRenewDomain_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v := formBody(t, r)
 		if v.Get("term") != "12" || v.Get("options[privacy]") != "1" {
@@ -66,13 +72,14 @@ func TestRenewDomain_Success(t *testing.T) {
 	defer srv.Close()
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
 	if _, err := New(c).RenewDomain(context.Background(), RenewDomainOptions{
-		Domain: "example.com", Term: 12, Privacy: "1",
+		Domain: testComDomain, Term: 12, Privacy: "1",
 	}); err != nil {
 		t.Fatalf("RenewDomain: %v", err)
 	}
 }
 
 func TestUpdateDomain_RequiresDomain(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
 	if _, err := New(c).UpdateDomain(context.Background(), UpdateDomainOptions{}); err == nil {
 		t.Fatal("expected error for missing Domain")
@@ -80,11 +87,12 @@ func TestUpdateDomain_RequiresDomain(t *testing.T) {
 }
 
 func TestTLDsAvailable_GET(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
 			t.Errorf("method = %q", r.Method)
 		}
-		if r.URL.Query().Get("domain") != "example.com" {
+		if r.URL.Query().Get("domain") != testComDomain {
 			t.Errorf("query = %v", r.URL.Query())
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -92,7 +100,7 @@ func TestTLDsAvailable_GET(t *testing.T) {
 	}))
 	defer srv.Close()
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
-	got, err := New(c).TLDsAvailable(context.Background(), TLDsAvailableOptions{Domain: "example.com"})
+	got, err := New(c).TLDsAvailable(context.Background(), TLDsAvailableOptions{Domain: testComDomain})
 	if err != nil {
 		t.Fatalf("TLDsAvailable: %v", err)
 	}
@@ -104,12 +112,13 @@ func TestTLDsAvailable_GET(t *testing.T) {
 // ---------------- Tier 4: UDAI / transfer ----------------
 
 func TestNewUDAI_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/srs/new_udai.json" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		v := formBody(t, r)
-		if v.Get("domain") != "example.com" {
+		if v.Get("domain") != testComDomain {
 			t.Errorf("domain = %q", v.Get("domain"))
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -117,12 +126,13 @@ func TestNewUDAI_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
-	if _, err := New(c).NewUDAI(context.Background(), NewUDAIOptions{Domain: "example.com"}); err != nil {
+	if _, err := New(c).NewUDAI(context.Background(), NewUDAIOptions{Domain: testComDomain}); err != nil {
 		t.Fatalf("NewUDAI: %v", err)
 	}
 }
 
 func TestValidateUDAI_RequiresBoth(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
 	if _, err := New(c).ValidateUDAI(context.Background(), ValidateUDAIOptions{Domain: "x"}); err == nil {
 		t.Fatal("expected error for missing UDAI")
@@ -133,9 +143,10 @@ func TestValidateUDAI_RequiresBoth(t *testing.T) {
 }
 
 func TestValidateUDAI_GET(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
-		if q.Get("domain") != "example.com" || q.Get("udai") != "ABC123" {
+		if q.Get("domain") != testComDomain || q.Get("udai") != "ABC123" {
 			t.Errorf("query = %v", q)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -144,16 +155,17 @@ func TestValidateUDAI_GET(t *testing.T) {
 	defer srv.Close()
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
 	if _, err := New(c).ValidateUDAI(context.Background(), ValidateUDAIOptions{
-		Domain: "example.com", UDAI: "ABC123",
+		Domain: testComDomain, UDAI: "ABC123",
 	}); err != nil {
 		t.Fatalf("ValidateUDAI: %v", err)
 	}
 }
 
 func TestTransferDomain_EncodesAllParams(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v := formBody(t, r)
-		if v.Get("domain") != "example.com" || v.Get("udai") != "ABC" {
+		if v.Get("domain") != testComDomain || v.Get("udai") != "ABC" {
 			t.Errorf("body = %v", v)
 		}
 		if v.Get("params[registrant_contact_id]") != "10" {
@@ -171,7 +183,7 @@ func TestTransferDomain_EncodesAllParams(t *testing.T) {
 	defer srv.Close()
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
 	if _, err := New(c).TransferDomain(context.Background(), TransferDomainOptions{
-		Domain: "example.com", UDAI: "ABC",
+		Domain: testComDomain, UDAI: "ABC",
 		RegistrantContactID: 10, AdminContactID: 11, TechnicalContactID: 12,
 		Term:        12,
 		NameServers: []NameServerEntry{{Name: "ns1.example.com"}},
@@ -181,6 +193,7 @@ func TestTransferDomain_EncodesAllParams(t *testing.T) {
 }
 
 func TestVerifyEmailToken_RequiresToken(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
 	if _, err := New(c).VerifyEmailToken(context.Background(), VerifyEmailTokenOptions{}); err == nil {
 		t.Fatal("expected error for missing Token")
@@ -190,6 +203,7 @@ func TestVerifyEmailToken_RequiresToken(t *testing.T) {
 // ---------------- Tier 5: email templates ----------------
 
 func TestListEmailTemplates_GET(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" || r.URL.Path != "/srs/list_email_templates.json" {
 			t.Errorf("method/path = %q %q", r.Method, r.URL.Path)
@@ -203,14 +217,15 @@ func TestListEmailTemplates_GET(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListEmailTemplates: %v", err)
 	}
-	if len(got.Return) != 1 || got.Return[0].Name != "renewal" {
+	if len(got.Return) != 1 || got.Return[0].Name != testTemplate {
 		t.Errorf("Return = %+v", got.Return)
 	}
 }
 
 func TestGetEmailTemplate_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("template") != "renewal" {
+		if r.URL.Query().Get("template") != testTemplate {
 			t.Errorf("template = %q", r.URL.Query().Get("template"))
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -218,7 +233,7 @@ func TestGetEmailTemplate_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
-	got, err := New(c).GetEmailTemplate(context.Background(), GetEmailTemplateOptions{Template: "renewal"})
+	got, err := New(c).GetEmailTemplate(context.Background(), GetEmailTemplateOptions{Template: testTemplate})
 	if err != nil {
 		t.Fatalf("GetEmailTemplate: %v", err)
 	}
@@ -228,6 +243,7 @@ func TestGetEmailTemplate_Success(t *testing.T) {
 }
 
 func TestUpdateEmailTemplate_OmitsEmpty(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v := formBody(t, r)
 		if v.Get("template") != "renewal" {
@@ -252,6 +268,7 @@ func TestUpdateEmailTemplate_OmitsEmpty(t *testing.T) {
 }
 
 func TestUpdateEmailTemplate_RequiresTemplate(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
 	if _, err := New(c).UpdateEmailTemplate(context.Background(), UpdateEmailTemplateOptions{}); err == nil {
 		t.Fatal("expected error for missing Template")

--- a/pkg/api/srs/tier3_5_writes_test.go
+++ b/pkg/api/srs/tier3_5_writes_test.go
@@ -1,0 +1,259 @@
+package srs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+// ---------------- Tier 3: domain mutators ----------------
+
+func TestAddNameServers_EncodesArray(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/srs/add_name_servers.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := formBody(t, r)
+		if v.Get("domain") != "example.com" ||
+			v.Get("nameservers[0][name]") != "ns1.example.com" ||
+			v.Get("nameservers[1][name]") != "ns2.example.com" ||
+			v.Get("nameservers[0][ipv4addr]") != "192.0.2.1" {
+			t.Errorf("body = %v", v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK"}`)
+	}))
+	defer srv.Close()
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).AddNameServers(context.Background(), AddNameServersOptions{
+		Domain: "example.com",
+		NameServers: []NameServerEntry{
+			{Name: "ns1.example.com", IPv4Addr: "192.0.2.1"},
+			{Name: "ns2.example.com"},
+		},
+	}); err != nil {
+		t.Fatalf("AddNameServers: %v", err)
+	}
+}
+
+func TestAddNameServers_RequiresAtLeastOne(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	if _, err := New(c).AddNameServers(context.Background(), AddNameServersOptions{Domain: "example.com"}); err == nil {
+		t.Fatal("expected error for empty NameServers")
+	}
+}
+
+func TestRenewDomain_RequiresTerm(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	if _, err := New(c).RenewDomain(context.Background(), RenewDomainOptions{Domain: "example.com"}); err == nil {
+		t.Fatal("expected error for Term=0")
+	}
+}
+
+func TestRenewDomain_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := formBody(t, r)
+		if v.Get("term") != "12" || v.Get("options[privacy]") != "1" {
+			t.Errorf("body = %v", v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK"}`)
+	}))
+	defer srv.Close()
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).RenewDomain(context.Background(), RenewDomainOptions{
+		Domain: "example.com", Term: 12, Privacy: "1",
+	}); err != nil {
+		t.Fatalf("RenewDomain: %v", err)
+	}
+}
+
+func TestUpdateDomain_RequiresDomain(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	if _, err := New(c).UpdateDomain(context.Background(), UpdateDomainOptions{}); err == nil {
+		t.Fatal("expected error for missing Domain")
+	}
+}
+
+func TestTLDsAvailable_GET(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Query().Get("domain") != "example.com" {
+			t.Errorf("query = %v", r.URL.Query())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"domain":"example.com","available":true}}`)
+	}))
+	defer srv.Close()
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).TLDsAvailable(context.Background(), TLDsAvailableOptions{Domain: "example.com"})
+	if err != nil {
+		t.Fatalf("TLDsAvailable: %v", err)
+	}
+	if !got.Return.Available {
+		t.Errorf("Available = %v", got.Return.Available)
+	}
+}
+
+// ---------------- Tier 4: UDAI / transfer ----------------
+
+func TestNewUDAI_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/srs/new_udai.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		v := formBody(t, r)
+		if v.Get("domain") != "example.com" {
+			t.Errorf("domain = %q", v.Get("domain"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK"}`)
+	}))
+	defer srv.Close()
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).NewUDAI(context.Background(), NewUDAIOptions{Domain: "example.com"}); err != nil {
+		t.Fatalf("NewUDAI: %v", err)
+	}
+}
+
+func TestValidateUDAI_RequiresBoth(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	if _, err := New(c).ValidateUDAI(context.Background(), ValidateUDAIOptions{Domain: "x"}); err == nil {
+		t.Fatal("expected error for missing UDAI")
+	}
+	if _, err := New(c).ValidateUDAI(context.Background(), ValidateUDAIOptions{UDAI: "x"}); err == nil {
+		t.Fatal("expected error for missing Domain")
+	}
+}
+
+func TestValidateUDAI_GET(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("domain") != "example.com" || q.Get("udai") != "ABC123" {
+			t.Errorf("query = %v", q)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK"}`)
+	}))
+	defer srv.Close()
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).ValidateUDAI(context.Background(), ValidateUDAIOptions{
+		Domain: "example.com", UDAI: "ABC123",
+	}); err != nil {
+		t.Fatalf("ValidateUDAI: %v", err)
+	}
+}
+
+func TestTransferDomain_EncodesAllParams(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := formBody(t, r)
+		if v.Get("domain") != "example.com" || v.Get("udai") != "ABC" {
+			t.Errorf("body = %v", v)
+		}
+		if v.Get("params[registrant_contact_id]") != "10" {
+			t.Errorf("registrant = %q", v.Get("params[registrant_contact_id]"))
+		}
+		if v.Get("params[term]") != "12" {
+			t.Errorf("term = %q", v.Get("params[term]"))
+		}
+		if v.Get("params[nameservers][0][name]") != "ns1.example.com" {
+			t.Errorf("ns0 = %q", v.Get("params[nameservers][0][name]"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK"}`)
+	}))
+	defer srv.Close()
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).TransferDomain(context.Background(), TransferDomainOptions{
+		Domain: "example.com", UDAI: "ABC",
+		RegistrantContactID: 10, AdminContactID: 11, TechnicalContactID: 12,
+		Term:        12,
+		NameServers: []NameServerEntry{{Name: "ns1.example.com"}},
+	}); err != nil {
+		t.Fatalf("TransferDomain: %v", err)
+	}
+}
+
+func TestVerifyEmailToken_RequiresToken(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	if _, err := New(c).VerifyEmailToken(context.Background(), VerifyEmailTokenOptions{}); err == nil {
+		t.Fatal("expected error for missing Token")
+	}
+}
+
+// ---------------- Tier 5: email templates ----------------
+
+func TestListEmailTemplates_GET(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || r.URL.Path != "/srs/list_email_templates.json" {
+			t.Errorf("method/path = %q %q", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":[{"name":"renewal","subject":"S","template":"T","type":"AutoRenewReminder"}]}`)
+	}))
+	defer srv.Close()
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).ListEmailTemplates(context.Background())
+	if err != nil {
+		t.Fatalf("ListEmailTemplates: %v", err)
+	}
+	if len(got.Return) != 1 || got.Return[0].Name != "renewal" {
+		t.Errorf("Return = %+v", got.Return)
+	}
+}
+
+func TestGetEmailTemplate_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("template") != "renewal" {
+			t.Errorf("template = %q", r.URL.Query().Get("template"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"name":"renewal","subject":"S","template":"T","type":"AutoRenewReminder"}}`)
+	}))
+	defer srv.Close()
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).GetEmailTemplate(context.Background(), GetEmailTemplateOptions{Template: "renewal"})
+	if err != nil {
+		t.Fatalf("GetEmailTemplate: %v", err)
+	}
+	if got.Return.Subject != "S" {
+		t.Errorf("Subject = %q", got.Return.Subject)
+	}
+}
+
+func TestUpdateEmailTemplate_OmitsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := formBody(t, r)
+		if v.Get("template") != "renewal" {
+			t.Errorf("template = %q", v.Get("template"))
+		}
+		if v.Get("params[EmailSubject]") != "New" {
+			t.Errorf("subject = %q", v.Get("params[EmailSubject]"))
+		}
+		if _, ok := v["params[EmailTemplate]"]; ok {
+			t.Errorf("EmailTemplate should be omitted when empty")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK"}`)
+	}))
+	defer srv.Close()
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).UpdateEmailTemplate(context.Background(), UpdateEmailTemplateOptions{
+		Template: "renewal", EmailSubject: "New",
+	}); err != nil {
+		t.Fatalf("UpdateEmailTemplate: %v", err)
+	}
+}
+
+func TestUpdateEmailTemplate_RequiresTemplate(t *testing.T) {
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	if _, err := New(c).UpdateEmailTemplate(context.Background(), UpdateEmailTemplateOptions{}); err == nil {
+		t.Fatal("expected error for missing Template")
+	}
+}

--- a/pkg/api/srs/tld_query.go
+++ b/pkg/api/srs/tld_query.go
@@ -17,7 +17,7 @@ import (
 // `srs/domain_available.json`. A bare label without TLD is rejected
 // with "Please specify a valid domain name." If a true multi-TLD
 // fan-out parameter exists it isn't documented and we couldn't
-// surface it via probing — see docs/api-issues/.
+// surface it via probing.
 type TLDsAvailableOptions struct {
 	Domain string `url:"domain"`
 }

--- a/pkg/api/srs/tld_query.go
+++ b/pkg/api/srs/tld_query.go
@@ -1,0 +1,56 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/models"
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// TLDsAvailableOptions checks domain availability via
+// "srs/domain_tlds_available.json" (GET).
+//
+// Despite the plural-TLD endpoint name, live behaviour (May 2026)
+// is single-domain: requires a fully-qualified `domain=<label>.<tld>`
+// and returns `{domain, available}` — the same shape as
+// `srs/domain_available.json`. A bare label without TLD is rejected
+// with "Please specify a valid domain name." If a true multi-TLD
+// fan-out parameter exists it isn't documented and we couldn't
+// surface it via probing — see docs/api-issues/.
+type TLDsAvailableOptions struct {
+	Domain string `url:"domain"`
+}
+
+// TLDsAvailableReturn is the inner payload — same shape as
+// srs.DomainAvailable.
+type TLDsAvailableReturn struct {
+	Domain    string `json:"domain"`
+	Available bool   `json:"available"`
+}
+
+// TLDsAvailableResponse mirrors the live single-domain payload.
+type TLDsAvailableResponse struct {
+	Return TLDsAvailableReturn `json:"return"`
+	models.APIResponse
+}
+
+// TLDsAvailable performs a multi-TLD availability check via
+// "srs/domain_tlds_available.json" (GET).
+func (s *Client) TLDsAvailable(ctx context.Context, opt TLDsAvailableOptions) (response TLDsAvailableResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.TLDsAvailable: Domain is required")
+	}
+	path, err := net.AddOptions("srs/domain_tlds_available.json", opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/tldresponse.go
+++ b/pkg/api/srs/tldresponse.go
@@ -1,0 +1,37 @@
+package srs
+
+import "github.com/sitehostnz/gosh/pkg/models"
+
+type (
+	// TLD describes a supported TLD's properties.
+	TLD struct {
+		TLD         string `json:"tld"`
+		Term        string `json:"term"`
+		Type        string `json:"type"`
+		CanTransfer string `json:"can_transfer"`
+		CanProtect  string `json:"can_protect"`
+		DateAdded   string `json:"date_added"`
+		DateUpdated string `json:"date_updated"`
+	}
+
+	// ListValidTLDsResponse represents the response from list_valid_tlds.
+	ListValidTLDsResponse struct {
+		Return []TLD `json:"return"`
+		models.APIResponse
+	}
+
+	// PricingTier describes a single pricing tier (count threshold,
+	// price at that tier).
+	PricingTier struct {
+		Type     int    `json:"type"`
+		TypeName string `json:"type_name"`
+		Count    string `json:"count"`
+		Price    string `json:"price"`
+	}
+
+	// GetPricingTiersResponse represents the response from get_pricing_tiers.
+	GetPricingTiersResponse struct {
+		Return []PricingTier `json:"return"`
+		models.APIResponse
+	}
+)

--- a/pkg/api/srs/transfer_domain.go
+++ b/pkg/api/srs/transfer_domain.go
@@ -1,0 +1,100 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// TransferDomainOptions submits a domain-transfer-in request via
+// "srs/transfer_domain.json".
+//
+// **Cost warning:** transfers typically charge a renewal-priced
+// term at the registry and add a year (or `params[term]` months)
+// to the expiry. Confirm pricing via srs.GetDomainPrice with
+// type="transfer" before calling.
+//
+// Required:
+//   - Domain — the domain to transfer in.
+//
+// Conditionally required:
+//   - UDAI — the registry auth code from the losing registrar.
+//     Required for TLDs that use UDAI/auth-code transfers (.nz,
+//     gTLDs). Some legacy registries don't require it.
+//
+// Optional but commonly required by registries:
+//   - RegistrantContactID, AdminContactID, TechnicalContactID,
+//     BillingContactID — defaults to the account's primary
+//     contact when omitted, but most registries require an
+//     explicit registrant on transfer-in.
+//   - Term — months. Defaults to the registry minimum (typically
+//     12).
+//   - NameServers — initial nameserver set. Defaults to the
+//     existing set carried over from the losing registrar.
+type TransferDomainOptions struct {
+	Domain              string
+	UDAI                string
+	RegistrantContactID int
+	AdminContactID      int
+	TechnicalContactID  int
+	BillingContactID    int
+	Term                int
+	NameServers         []NameServerEntry
+}
+
+// TransferDomain initiates an inbound domain transfer via
+// "srs/transfer_domain.json".
+//
+// Live-validating this endpoint requires a domain held at another
+// registrar plus a valid UDAI — gosh's test suite stops at unit
+// tests for this reason. The wrapper is intentionally minimal:
+// it forwards the documented parameters as-is.
+func (s *Client) TransferDomain(ctx context.Context, opt TransferDomainOptions) (response models.APIResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.TransferDomain: Domain is required")
+	}
+	values := url.Values{}
+	values.Set("domain", opt.Domain)
+	if opt.UDAI != "" {
+		values.Set("udai", opt.UDAI)
+	}
+	if opt.RegistrantContactID != 0 {
+		values.Set("params[registrant_contact_id]", strconv.Itoa(opt.RegistrantContactID))
+	}
+	if opt.AdminContactID != 0 {
+		values.Set("params[admin_contact_id]", strconv.Itoa(opt.AdminContactID))
+	}
+	if opt.TechnicalContactID != 0 {
+		values.Set("params[technical_contact_id]", strconv.Itoa(opt.TechnicalContactID))
+	}
+	if opt.BillingContactID != 0 {
+		values.Set("params[billing_contact_id]", strconv.Itoa(opt.BillingContactID))
+	}
+	if opt.Term > 0 {
+		values.Set("params[term]", strconv.Itoa(opt.Term))
+	}
+	for i, ns := range opt.NameServers {
+		if ns.Name == "" {
+			return response, fmt.Errorf("srs.TransferDomain: NameServers[%d].Name is required", i)
+		}
+		idx := strconv.Itoa(i)
+		values.Set("params[nameservers]["+idx+"][name]", ns.Name)
+		if ns.IPv4Addr != "" {
+			values.Set("params[nameservers]["+idx+"][ipv4addr]", ns.IPv4Addr)
+		}
+		if ns.IPv6Addr != "" {
+			values.Set("params[nameservers]["+idx+"][ipv6addr]", ns.IPv6Addr)
+		}
+	}
+	req, err := s.client.NewRequest("POST", "srs/transfer_domain.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/transfer_domain.go
+++ b/pkg/api/srs/transfer_domain.go
@@ -56,38 +56,9 @@ func (s *Client) TransferDomain(ctx context.Context, opt TransferDomainOptions) 
 	if opt.Domain == "" {
 		return response, fmt.Errorf("srs.TransferDomain: Domain is required")
 	}
-	values := url.Values{}
-	values.Set("domain", opt.Domain)
-	if opt.UDAI != "" {
-		values.Set("udai", opt.UDAI)
-	}
-	if opt.RegistrantContactID != 0 {
-		values.Set("params[registrant_contact_id]", strconv.Itoa(opt.RegistrantContactID))
-	}
-	if opt.AdminContactID != 0 {
-		values.Set("params[admin_contact_id]", strconv.Itoa(opt.AdminContactID))
-	}
-	if opt.TechnicalContactID != 0 {
-		values.Set("params[technical_contact_id]", strconv.Itoa(opt.TechnicalContactID))
-	}
-	if opt.BillingContactID != 0 {
-		values.Set("params[billing_contact_id]", strconv.Itoa(opt.BillingContactID))
-	}
-	if opt.Term > 0 {
-		values.Set("params[term]", strconv.Itoa(opt.Term))
-	}
-	for i, ns := range opt.NameServers {
-		if ns.Name == "" {
-			return response, fmt.Errorf("srs.TransferDomain: NameServers[%d].Name is required", i)
-		}
-		idx := strconv.Itoa(i)
-		values.Set("params[nameservers]["+idx+"][name]", ns.Name)
-		if ns.IPv4Addr != "" {
-			values.Set("params[nameservers]["+idx+"][ipv4addr]", ns.IPv4Addr)
-		}
-		if ns.IPv6Addr != "" {
-			values.Set("params[nameservers]["+idx+"][ipv6addr]", ns.IPv6Addr)
-		}
+	values, err := encodeTransferDomain(opt)
+	if err != nil {
+		return response, err
 	}
 	req, err := s.client.NewRequest("POST", "srs/transfer_domain.json", values.Encode())
 	if err != nil {
@@ -97,4 +68,44 @@ func (s *Client) TransferDomain(ctx context.Context, opt TransferDomainOptions) 
 		return response, err
 	}
 	return response, nil
+}
+
+func encodeTransferDomain(opt TransferDomainOptions) (url.Values, error) {
+	values := url.Values{}
+	values.Set("domain", opt.Domain)
+	setNonEmpty(values, "udai", opt.UDAI)
+	setNonZero(values, "params[registrant_contact_id]", opt.RegistrantContactID)
+	setNonZero(values, "params[admin_contact_id]", opt.AdminContactID)
+	setNonZero(values, "params[technical_contact_id]", opt.TechnicalContactID)
+	setNonZero(values, "params[billing_contact_id]", opt.BillingContactID)
+	setNonZero(values, "params[term]", opt.Term)
+	if err := encodeNameServersParam(values, opt.NameServers); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+func encodeNameServersParam(values url.Values, nss []NameServerEntry) error {
+	for i, ns := range nss {
+		if ns.Name == "" {
+			return fmt.Errorf("srs.TransferDomain: NameServers[%d].Name is required", i)
+		}
+		idx := strconv.Itoa(i)
+		values.Set("params[nameservers]["+idx+"][name]", ns.Name)
+		setNonEmpty(values, "params[nameservers]["+idx+"][ipv4addr]", ns.IPv4Addr)
+		setNonEmpty(values, "params[nameservers]["+idx+"][ipv6addr]", ns.IPv6Addr)
+	}
+	return nil
+}
+
+func setNonEmpty(values url.Values, key, val string) {
+	if val != "" {
+		values.Set(key, val)
+	}
+}
+
+func setNonZero(values url.Values, key string, val int) {
+	if val != 0 {
+		values.Set(key, strconv.Itoa(val))
+	}
 }

--- a/pkg/api/srs/udai.go
+++ b/pkg/api/srs/udai.go
@@ -1,0 +1,93 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// NewUDAIOptions requests a fresh UDAI (transfer authorisation
+// code) for a domain via "srs/new_udai.json".
+//
+// The UDAI is sent by the registry to the registrant's email on
+// record. This endpoint does not return the code in its response;
+// it triggers the email and returns a {status, msg} envelope.
+//
+// Use cases:
+//
+//   - Transferring a .nz domain *out* to another registrar — the
+//     gaining registrar needs the UDAI from the registrant.
+//   - Refreshing a stale or compromised UDAI.
+//
+// Behaviour is TLD-specific: .nz uses UDAI as its sole transfer-
+// authorisation mechanism (no EPP-style transfer locks); gTLDs
+// (.com, .net) use a different "auth code" concept that may or
+// may not be exposed via this endpoint depending on registrar
+// configuration.
+type NewUDAIOptions struct {
+	Domain string `url:"domain"`
+}
+
+// NewUDAI generates a fresh UDAI (auth code) for a domain via
+// "srs/new_udai.json". The code is delivered by email to the
+// registrant; it is not returned in the response.
+func (s *Client) NewUDAI(ctx context.Context, opt NewUDAIOptions) (response models.APIResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.NewUDAI: Domain is required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/new_udai.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+// ValidateUDAIOptions checks whether a UDAI (auth code) is valid
+// for a domain via "srs/validate_udai.json" (GET). Both fields are
+// required.
+//
+// Used by the *gaining* registrar before submitting a transfer:
+// validate the code first to catch typos or expired codes before
+// kicking off the registry transfer process.
+//
+// The public docs do not list a parameter table; the inferred
+// shape is domain=...&udai=.... Validate live before relying on
+// the response shape.
+type ValidateUDAIOptions struct {
+	Domain string `url:"domain"`
+	UDAI   string `url:"udai"`
+}
+
+// ValidateUDAI checks a UDAI code via "srs/validate_udai.json".
+// Returns the bare {status, msg} envelope; status=true means the
+// code is valid for the domain, false means rejected.
+func (s *Client) ValidateUDAI(ctx context.Context, opt ValidateUDAIOptions) (response models.APIResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.ValidateUDAI: Domain is required")
+	}
+	if opt.UDAI == "" {
+		return response, fmt.Errorf("srs.ValidateUDAI: UDAI is required")
+	}
+	path, err := net.AddOptions("srs/validate_udai.json", opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/update_domain.go
+++ b/pkg/api/srs/update_domain.go
@@ -1,0 +1,45 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// UpdateDomainOptions triggers a domain-record refresh via
+// "srs/update_domain.json".
+//
+// The public docs only list client_id and domain as parameters;
+// no params[*] block is documented. In practice the endpoint
+// reconciles the local SiteHost record with the registry's view
+// (whois, expiry, contact bindings, nameservers). It does not
+// take new field values — for those use the role-specific
+// endpoints (UpdateDomainContacts, AddNameServers, etc.).
+//
+// Returns the bare {status, msg} envelope. Re-read with
+// srs.GetDomain afterwards to observe any changes.
+type UpdateDomainOptions struct {
+	Domain string `url:"domain"`
+}
+
+// UpdateDomain refreshes a domain record from the registry via
+// "srs/update_domain.json".
+func (s *Client) UpdateDomain(ctx context.Context, opt UpdateDomainOptions) (response models.APIResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.UpdateDomain: Domain is required")
+	}
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "srs/update_domain.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/verify_email_token.go
+++ b/pkg/api/srs/verify_email_token.go
@@ -1,0 +1,49 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/models"
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// VerifyEmailTokenOptions verifies a registrant-email confirmation
+// token via "srs/verify_email_token.json" (GET).
+//
+// Background: when a contact's email changes (or a new domain is
+// registered), some registries (notably ICANN-governed gTLDs)
+// require the registrant to confirm ownership of the email by
+// clicking a link. The link carries a token; this endpoint marks
+// the token as confirmed.
+//
+// The public docs do not list parameters; the inferred shape is
+// `?token=...`. Validate live before relying on the response shape.
+//
+// This endpoint is typically driven by the end-user clicking a
+// link in the verification email rather than called from server
+// code; it's wrapped here for completeness and for any automated
+// re-verification flows.
+type VerifyEmailTokenOptions struct {
+	Token string `url:"token"`
+}
+
+// VerifyEmailToken confirms a registrant-email verification token
+// via "srs/verify_email_token.json".
+func (s *Client) VerifyEmailToken(ctx context.Context, opt VerifyEmailTokenOptions) (response models.APIResponse, err error) {
+	if opt.Token == "" {
+		return response, fmt.Errorf("srs.VerifyEmailToken: Token is required")
+	}
+	path, err := net.AddOptions("srs/verify_email_token.json", opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/srs/whois.go
+++ b/pkg/api/srs/whois.go
@@ -1,0 +1,39 @@
+package srs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Whois performs a whois lookup for the given domain via
+// "srs/whois.json". The Domain field of opt is required.
+//
+// The endpoint is documented at https://docs.sitehost.nz/api/v1.5/?path=/srs.
+// JSON keys in the response use PascalCase (DomainName, Status,
+// RegisteredDate, ...) reflecting the underlying registry schema —
+// see Whois and WhoisContact in whoisresponse.go.
+func (s *Client) Whois(ctx context.Context, opt WhoisOptions) (response WhoisResponse, err error) {
+	if opt.Domain == "" {
+		return response, fmt.Errorf("srs.Whois: Domain is required")
+	}
+
+	u := "srs/whois.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	httpReq, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, httpReq, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/srs/whois_test.go
+++ b/pkg/api/srs/whois_test.go
@@ -1,0 +1,118 @@
+package srs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestWhois_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/srs/whois.json" {
+			t.Errorf("path = %q, want /srs/whois.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("domain"); got != "example.co.nz" {
+			t.Errorf("domain = %q, want example.co.nz", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful.",
+			"SourceIP": "203.0.113.10",
+			"return": {
+				"DomainName": "example.co.nz",
+				"Status":     "Active",
+				"RegisteredDate": "2020-01-01 00:00:00",
+				"ModifiedDate":   "2025-04-15 00:00:00",
+				"BilledUntil":    "2026-01-01 00:00:00",
+				"NameServers": [
+					{"FQDN": "ns1.sitehost.nz", "IP4Addr": "203.0.113.1", "IP6Addr": "2001:db8::1"},
+					{"FQDN": "ns2.sitehost.nz", "IP4Addr": "203.0.113.2", "IP6Addr": "2001:db8::2"}
+				],
+				"RegistrantContact": {
+					"Name": "Alice Example",
+					"Company": "Example Ltd",
+					"Email": "alice@example.co.nz",
+					"PostalAddress": {"Country": "NZ"}
+				},
+				"TechnicalContact": {
+					"Name": "Bob Example",
+					"Company": "",
+					"Email": "bob@example.co.nz",
+					"PostalAddress": {"Country": "NZ"}
+				},
+				"AdminContact": {
+					"Name": "Carol Example",
+					"Company": "",
+					"Email": "carol@example.co.nz",
+					"PostalAddress": {"Country": "NZ"}
+				}
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).Whois(context.Background(), WhoisOptions{Domain: "example.co.nz"})
+	if err != nil {
+		t.Fatalf("Whois: %v", err)
+	}
+
+	if !got.Status {
+		t.Errorf("Status = false, want true")
+	}
+	if got.SourceIP != "203.0.113.10" {
+		t.Errorf("SourceIP = %q, want 203.0.113.10", got.SourceIP)
+	}
+	if got.Return.Domain != "example.co.nz" {
+		t.Errorf("Return.Domain = %q, want example.co.nz", got.Return.Domain)
+	}
+	if got.Return.State != "Active" {
+		t.Errorf("Return.State = %q, want Active", got.Return.State)
+	}
+	if len(got.Return.NameServers) != 2 {
+		t.Fatalf("len(NameServers) = %d, want 2", len(got.Return.NameServers))
+	}
+	if got.Return.NameServers[0].FQDN != "ns1.sitehost.nz" {
+		t.Errorf("NameServers[0].FQDN = %q, want ns1.sitehost.nz", got.Return.NameServers[0].FQDN)
+	}
+	if got.Return.Registrant.Name != "Alice Example" {
+		t.Errorf("Registrant.Name = %q, want Alice Example", got.Return.Registrant.Name)
+	}
+	if got.Return.Registrant.Company != "Example Ltd" {
+		t.Errorf("Registrant.Company = %q, want Example Ltd", got.Return.Registrant.Company)
+	}
+	if got.Return.Registrant.Email != "alice@example.co.nz" {
+		t.Errorf("Registrant.Email = %q, want alice@example.co.nz", got.Return.Registrant.Email)
+	}
+	if got := got.Return.Registrant.PostalAddress["Country"]; got != "NZ" {
+		t.Errorf("Registrant.PostalAddress[Country] = %q, want NZ", got)
+	}
+}
+
+func TestWhois_DomainRequired(t *testing.T) {
+	c, err := api.New("k", "1")
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	_, err = New(c).Whois(context.Background(), WhoisOptions{})
+	if err == nil {
+		t.Fatal("Whois: expected error for empty Domain, got nil")
+	}
+	if !strings.Contains(err.Error(), "Domain is required") {
+		t.Errorf("error = %q, want it to contain 'Domain is required'", err.Error())
+	}
+}

--- a/pkg/api/srs/whois_test.go
+++ b/pkg/api/srs/whois_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestWhois_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("method = %q, want GET", r.Method)
@@ -103,6 +104,7 @@ func TestWhois_Success(t *testing.T) {
 }
 
 func TestWhois_DomainRequired(t *testing.T) {
+	t.Parallel()
 	c, err := api.New("k", "1")
 	if err != nil {
 		t.Fatalf("api.New: %v", err)

--- a/pkg/api/srs/whoisrequest.go
+++ b/pkg/api/srs/whoisrequest.go
@@ -1,0 +1,9 @@
+package srs
+
+type (
+	// WhoisOptions represents the parameters for a whois lookup. Domain
+	// is required.
+	WhoisOptions struct {
+		Domain string `url:"domain"`
+	}
+)

--- a/pkg/api/srs/whoisresponse.go
+++ b/pkg/api/srs/whoisresponse.go
@@ -1,0 +1,49 @@
+package srs
+
+import "github.com/sitehostnz/gosh/pkg/models"
+
+type (
+	// WhoisContact is a contact block within a whois response. The
+	// PostalAddress field is itself a key/value map because the
+	// underlying registry returns a variable set of address fields
+	// per domain (e.g. {"Country": "NZ"} for some, with Street /
+	// City / Postcode for others) — using a map captures whatever
+	// the API returns without forcing speculation about field names.
+	WhoisContact struct {
+		Name          string            `json:"Name"`
+		Company       string            `json:"Company"`
+		Email         string            `json:"Email"`
+		PostalAddress map[string]string `json:"PostalAddress"`
+	}
+
+	// WhoisNameServer is a name-server entry within a whois response.
+	WhoisNameServer struct {
+		FQDN    string `json:"FQDN"`
+		IP4Addr string `json:"IP4Addr"`
+		IP6Addr string `json:"IP6Addr"`
+	}
+
+	// Whois is the structured whois result for a domain.
+	// Field-name capitalisation in the API is unusual (PascalCase JSON
+	// keys), reflecting the underlying registry response shape.
+	Whois struct {
+		Domain          string            `json:"DomainName"`
+		State           string            `json:"Status"`
+		DateRegistered  string            `json:"RegisteredDate"`
+		DateModified    string            `json:"ModifiedDate"`
+		DateBilledUntil string            `json:"BilledUntil"`
+		NameServers     []WhoisNameServer `json:"NameServers"`
+		Registrant      WhoisContact      `json:"RegistrantContact"`
+		Technical       WhoisContact      `json:"TechnicalContact"`
+		Admin           WhoisContact      `json:"AdminContact"`
+	}
+
+	// WhoisResponse represents the response from the whois endpoint.
+	// SourceIP is the address the whois query was sourced from
+	// (returned by the API alongside the registry data).
+	WhoisResponse struct {
+		Return   Whois  `json:"return"`
+		SourceIP string `json:"SourceIP"`
+		models.APIResponse
+	}
+)


### PR DESCRIPTION
## Summary

New \`pkg/api/srs\` package covering the full SRS (Shared Registry
System) surface — 37 endpoints across reads, .nz domain lifecycle,
contact CRUD, and registry-side writes.

Surface organised in 5 tiers, all live-validated against a real
.nz test domain (gosh-srs-test.nz, owned by submitter):

- **Reads** — list_domains, get_domain, list_contacts, get_contact,
  search_contacts, list_name_servers, list_valid_tlds, whois,
  domain_available, domain_inside_grace_period, get_domain_price,
  get_pricing_tiers, can_transfer_domain, get_company_info
- **Tier 1 writes** — lock_domain, unlock_domain (with .nz-rejection
  doc-comment), enable/disable_privacy_protection, update_auto_renew
- **Tier 2 writes** — create_contact, update_contact, delete_contact,
  update_domain_contacts, update_company_info
- **Tier 3 writes** — add_name_servers, renew_domain, update_domain,
  domain_tlds_available
- **Tier 4 writes** — new_udai, validate_udai, transfer_domain,
  verify_email_token
- **Tier 5 writes** — list/get/update_email_template

Doc-blocks at the wrapper level capture live-validated gotchas
that aren't in the public docs:

- create_contact requires \`params[Phone][Country|Area|Local]\`
  PascalCase sub-keys (the docs page lists them but easy to miss)
- create_contact rejects RFC-2606 reserved TLDs in email
  (.example, .test, .invalid)
- lock_domain is rejected on .nz (UDAI model, not EPP-style locks)
- get_email_templates: \`template\` param is required but no value
  derivable from list_email_templates is accepted —
  filed as an open API issue

## Test plan

- [x] unit tests across all 37 endpoints
- [x] live-validated against gosh-srs-test.nz: register → lock-attempt
      → privacy → autorenew → contact CRUD → domain-rebind → UDAI
      issuance → AddNameServers → list_email_templates round-trips
- [x] \`go build ./...\` and \`go test ./...\` clean

## Skipped from live validation (and why)

- \`renew_domain\` — charges the account; wrapper unit-tested only
- \`transfer_domain\` — needs a domain at another registrar plus a
  valid UDAI from the losing registrar
- \`update_email_template\` — account-wide impact on customer-facing
  emails; wrapper unit-tested only
- \`verify_email_token\` — no token in hand at validation time