### PR TITLE
mail: doc note that AddDomain rejects reserved TLDs

### DIFF
--- a/pkg/api/mail/request.go
+++ b/pkg/api/mail/request.go
@@ -137,6 +137,12 @@ type (
 	}
 
 	// AddDomainOptions describes a domain to add to the mail server.
+	//
+	// Domain is validated against a TLD allowlist server-side.
+	// RFC 2606 reserved test TLDs (.example, .test, .localhost,
+	// .invalid) are rejected with "Please specify a valid domain
+	// name." Use a domain on a real public-suffix TLD, or one of
+	// SiteHost's wildcard test domains (sth.nz) for SDK testing.
 	AddDomainOptions struct {
 		ServerOptions
 		Domain string `url:"domain"`


### PR DESCRIPTION
Doc-only follow-up from #46 review. The API validates `AddDomainOptions.Domain` against a TLD allowlist; RFC 2606 reserved TLDs (`.example`, `.test`, `.localhost`, `.invalid`) get rejected with "Please specify a valid domain name." Adds a doc note on `AddDomainOptions` so consumers reaching for a fake test domain see this upfront rather than learning at runtime.

No code change.