### PR TITLE
api: document the per-second rate limit at the package level

### DIFF
--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -1,4 +1,19 @@
 // Package api provides the functions to work with SiteHost API.
+//
+// # Rate limiting
+//
+// The SiteHost API enforces a per-second rate limit at roughly
+// 1 request/sec per API key. Bursts are rejected with HTTP 500 and
+// the body
+//
+//	You have exceeded the number of requests per second for this key.
+//
+// (sic — 500 rather than the more conventional 429). Consumers
+// running batched workloads — example programs, migrations,
+// reconciliation loops — should pace calls accordingly. ~1.1s
+// between calls completes round-trips cleanly in practice. The SDK
+// itself does not throttle; back-off and retry are the caller's
+// responsibility.
 package api
 
 import (


### PR DESCRIPTION
Doc-only follow-up from #46 review. The API enforces a per-second rate limit at ~1 req/sec per key; bursts are rejected with HTTP 500 (sic) and a specific body string. Belongs at the \`api\`-package level since it applies SDK-wide. The SDK doesn't throttle — pacing is on the caller.

No code change.