### PR TITLE
models: canonicalise mangled IPv6 in IPAddress.IP at unmarshal time

### DIFF
--- a/pkg/models/bandwidth.go
+++ b/pkg/models/bandwidth.go
@@ -1,18 +1,32 @@
 package models
 
+import (
+	"encoding/json"
+	"strings"
+)
+
 type (
 	// IPAddress does what it says on the can. It's an IP address.
 	//
-	// Caveat for IPv6: when this struct is populated from
-	// /bandwidth/get_ip_list.json the IP field comes back with ':'
+	// **IPv6 wire-shape quirk + normalisation.**
+	// /bandwidth/get_ip_list.json serialises IPv6 addresses with ':'
 	// replaced by '.' (and '::' as '..'), e.g.
-	// "2403.7000.8000.300..ce/128" instead of
+	// "2403.7000.8000.300..ce/128" rather than
 	// "2403:7000:8000:300::ce/128". The mangled form is rejected by
-	// any IP-input endpoint, so callers round-tripping IPv6 addresses
-	// from this field need to canonicalise them first. Localised to
-	// /bandwidth/get_ip_list.json — /bandwidth/get_usage_summary.json
-	// and /server/list_servers.json both emit canonical IPv6 in the
-	// same response.
+	// every IP-input endpoint, so a naive read-then-write round-trip
+	// breaks for IPv6 addresses retrieved from this struct.
+	//
+	// Custom UnmarshalJSON canonicalises the IP back to standard
+	// IPv6 syntax when Family is "6" — '..' → '::' first, then
+	// remaining '.' between hextets → ':'. IPv4 (family "4") is
+	// passed through untouched. After unmarshalling, the IP field
+	// is safe to feed back into any IP-input endpoint.
+	//
+	// The mangling is localised to /bandwidth/get_ip_list.json —
+	// /bandwidth/get_usage_summary.json and /server/list_servers.json
+	// both emit canonical IPv6 — but the normaliser is benign on
+	// already-canonical strings, so it doesn't matter where the
+	// IPAddress originated.
 	IPAddress struct {
 		IP            string `json:"ip_addr"`
 		Netmask       string `json:"netmask"`
@@ -23,3 +37,36 @@ type (
 		DateAllocated string `json:"date_allocated"`
 	}
 )
+
+// UnmarshalJSON normalises mangled IPv6 IP fields — see type docs.
+func (ip *IPAddress) UnmarshalJSON(data []byte) error {
+	type alias IPAddress
+	var raw alias
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw.Family == "6" {
+		raw.IP = canonicaliseMangledIPv6(raw.IP)
+	}
+	*ip = IPAddress(raw)
+	return nil
+}
+
+// canonicaliseMangledIPv6 reverses the dot-for-colon substitution the
+// /bandwidth/get_ip_list.json endpoint applies to IPv6 addresses.
+// Operates on the address part only; preserves any "/<prefix>"
+// suffix verbatim. Already-canonical input (no '.') is returned
+// unchanged.
+func canonicaliseMangledIPv6(s string) string {
+	if s == "" || !strings.Contains(s, ".") {
+		return s
+	}
+	addr, suffix := s, ""
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		addr, suffix = s[:i], s[i:]
+	}
+	// '..' first so '::' isn't subsequently mangled to ':::'.
+	addr = strings.ReplaceAll(addr, "..", "::")
+	addr = strings.ReplaceAll(addr, ".", ":")
+	return addr + suffix
+}

--- a/pkg/models/bandwidth_test.go
+++ b/pkg/models/bandwidth_test.go
@@ -1,0 +1,94 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestIPAddress_UnmarshalJSON_IPv4Untouched(t *testing.T) {
+	t.Parallel()
+	in := `{"ip_addr":"203.0.113.10/32","netmask":"255.255.255.0","prefix":"32","reserved":"0","rdns":"","addr_family":"4","date_allocated":""}`
+	var got IPAddress
+	if err := json.Unmarshal([]byte(in), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.IP != "203.0.113.10/32" {
+		t.Errorf("IP = %q, want untouched 203.0.113.10/32", got.IP)
+	}
+}
+
+func TestIPAddress_UnmarshalJSON_IPv6CanonicalUntouched(t *testing.T) {
+	t.Parallel()
+	in := `{"ip_addr":"2403:7000:8000:300::ce/128","addr_family":"6"}`
+	var got IPAddress
+	if err := json.Unmarshal([]byte(in), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.IP != "2403:7000:8000:300::ce/128" {
+		t.Errorf("IP = %q, want untouched canonical IPv6", got.IP)
+	}
+}
+
+func TestIPAddress_UnmarshalJSON_IPv6MangledShortForm(t *testing.T) {
+	t.Parallel()
+	// '::' → '..' shorthand mangling, the form /bandwidth/get_ip_list.json emits.
+	in := `{"ip_addr":"2403.7000.8000.300..ce/128","addr_family":"6"}`
+	var got IPAddress
+	if err := json.Unmarshal([]byte(in), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.IP != "2403:7000:8000:300::ce/128" {
+		t.Errorf("IP = %q, want 2403:7000:8000:300::ce/128", got.IP)
+	}
+}
+
+func TestIPAddress_UnmarshalJSON_IPv6MangledLongForm(t *testing.T) {
+	t.Parallel()
+	// IPv6 with all 8 hextets, no '::' shorthand — only single dots.
+	in := `{"ip_addr":"2403.7000.8000.c00.0.0.0.9b/128","addr_family":"6"}`
+	var got IPAddress
+	if err := json.Unmarshal([]byte(in), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.IP != "2403:7000:8000:c00:0:0:0:9b/128" {
+		t.Errorf("IP = %q, want 2403:7000:8000:c00:0:0:0:9b/128", got.IP)
+	}
+}
+
+func TestIPAddress_UnmarshalJSON_NoPrefix(t *testing.T) {
+	t.Parallel()
+	in := `{"ip_addr":"2403.7000.8000.300..ce","addr_family":"6"}`
+	var got IPAddress
+	if err := json.Unmarshal([]byte(in), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.IP != "2403:7000:8000:300::ce" {
+		t.Errorf("IP = %q, want 2403:7000:8000:300::ce", got.IP)
+	}
+}
+
+func TestIPAddress_UnmarshalJSON_EmptyIP(t *testing.T) {
+	t.Parallel()
+	in := `{"ip_addr":"","addr_family":"6"}`
+	var got IPAddress
+	if err := json.Unmarshal([]byte(in), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.IP != "" {
+		t.Errorf("IP = %q, want empty", got.IP)
+	}
+}
+
+func TestIPAddress_UnmarshalJSON_FamilyMissingPassesThrough(t *testing.T) {
+	t.Parallel()
+	// Without addr_family="6" we don't know it's IPv6, so don't transform.
+	// IPv4 has dots and we must not mangle it.
+	in := `{"ip_addr":"203.0.113.10/32"}`
+	var got IPAddress
+	if err := json.Unmarshal([]byte(in), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.IP != "203.0.113.10/32" {
+		t.Errorf("IP = %q, want untouched 203.0.113.10/32 (family unknown)", got.IP)
+	}
+}


### PR DESCRIPTION
Follow-up from PR #43 live-validation. \`/bandwidth/get_ip_list.json\` serialises IPv6 addresses with \`:\` replaced by \`.\` (and \`::\` as \`..\`), e.g. \`2403.7000.8000.300..ce/128\`. The mangled form is rejected by every IP-input endpoint, so a naive read-then-write round-trip breaks for IPv6.

This PR adds a custom \`UnmarshalJSON\` on \`models.IPAddress\` that canonicalises the IP back to standard syntax at decode time:

- Triggers only when \`Family == "6"\` so IPv4 dot-decimal is never mangled.
- \`..\` → \`::\` first, then remaining \`.\` → \`:\`.
- Benign on already-canonical input (the mangling is localised to \`/bandwidth/get_ip_list.json\`; \`/bandwidth/get_usage_summary.json\` and \`/server/list_servers.json\` emit canonical IPv6, but the normaliser leaves those untouched).
- Preserves any \`/<prefix>\` suffix verbatim.

After this lands, IP addresses retrieved from \`list_ips\` can be fed back into \`get_usage_by_*\`, \`update_reverse_dns\`, etc. without manual canonicalisation.

Test coverage:

- IPv4 untouched (with and without prefix)
- IPv6 canonical untouched
- IPv6 mangled with \`..\` shorthand → canonical with \`::\`
- IPv6 mangled long-form (8 hextets) → canonical with \`:\`
- Empty IP works
- Family-missing falls through (so unannotated callers don't accidentally mangle IPv4)

The mangling itself is a server-side bug; fixing it server-side would be the proper remedy. This SDK normaliser is defence-in-depth.