### PR TITLE
server: AddIP IP/IPVersion typed options + DeleteRequest.Force

### DIFF
--- a/pkg/api/server/addip.go
+++ b/pkg/api/server/addip.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+)
+
+// AddIP adds an IP address to a server via "server/add_ip.json".
+// Both Name and IP are required. Returns the scheduler job and
+// the IP that was added.
+func (s *Client) AddIP(ctx context.Context, opt AddIPOptions) (response IPJobResponse, err error) {
+	if opt.Name == "" {
+		return response, fmt.Errorf("server.AddIP: Name is required")
+	}
+	if opt.IP == "" {
+		return response, fmt.Errorf("server.AddIP: IP is required")
+	}
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "server/add_ip.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/server/addip.go
+++ b/pkg/api/server/addip.go
@@ -3,25 +3,26 @@ package server
 import (
 	"context"
 	"fmt"
-
-	"github.com/google/go-querystring/query"
+	"net/url"
+	"strconv"
 )
 
 // AddIP adds an IP address to a server via "server/add_ip.json".
-// Both Name and IP are required. Returns the scheduler job and
-// the IP that was added.
+// Set exactly one of opt.IP (a real address) or opt.IPVersion
+// (4 or 6 to auto-allocate). See [AddIPOptions] for the rationale.
 func (s *Client) AddIP(ctx context.Context, opt AddIPOptions) (response IPJobResponse, err error) {
 	if opt.Name == "" {
 		return response, fmt.Errorf("server.AddIP: Name is required")
 	}
-	if opt.IP == "" {
-		return response, fmt.Errorf("server.AddIP: IP is required")
-	}
-
-	values, err := query.Values(opt)
+	param, err := addIPParam(opt)
 	if err != nil {
 		return response, err
 	}
+
+	values := url.Values{}
+	values.Set("name", opt.Name)
+	values.Set("param", param)
+
 	req, err := s.client.NewRequest("POST", "server/add_ip.json", values.Encode())
 	if err != nil {
 		return response, err
@@ -30,4 +31,26 @@ func (s *Client) AddIP(ctx context.Context, opt AddIPOptions) (response IPJobRes
 		return response, err
 	}
 	return response, nil
+}
+
+// addIPParam resolves the wire-level `param` value from AddIPOptions:
+// the explicit address if IP is set, the family number if IPVersion
+// is set. Exactly one must be supplied; both-set or both-unset is
+// an error.
+func addIPParam(opt AddIPOptions) (string, error) {
+	hasIP := opt.IP != ""
+	hasVersion := opt.IPVersion != 0
+	switch {
+	case hasIP && hasVersion:
+		return "", fmt.Errorf("server.AddIP: set exactly one of IP or IPVersion (both supplied)")
+	case !hasIP && !hasVersion:
+		return "", fmt.Errorf("server.AddIP: set exactly one of IP or IPVersion (neither supplied)")
+	case hasIP:
+		return opt.IP, nil
+	default:
+		if opt.IPVersion != 4 && opt.IPVersion != 6 {
+			return "", fmt.Errorf("server.AddIP: IPVersion must be 4 or 6, got %d", opt.IPVersion)
+		}
+		return strconv.Itoa(opt.IPVersion), nil
+	}
 }

--- a/pkg/api/server/canprovision.go
+++ b/pkg/api/server/canprovision.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+	"github.com/sitehostnz/gosh/pkg/models"
+)
+
+// CanProvision checks resource availability for provisioning a
+// server product via "server/can_provision.json". Product,
+// Location, and Distro are required; Arch is optional.
+// Synchronous; returns models.APIResponse — Status indicates
+// whether the resources are available.
+func (s *Client) CanProvision(ctx context.Context, opt CanProvisionOptions) (response models.APIResponse, err error) {
+	if opt.Product == "" {
+		return response, fmt.Errorf("server.CanProvision: Product is required")
+	}
+	if opt.Location == "" {
+		return response, fmt.Errorf("server.CanProvision: Location is required")
+	}
+	if opt.Distro == "" {
+		return response, fmt.Errorf("server.CanProvision: Distro is required")
+	}
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "server/can_provision.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/server/changestate.go
+++ b/pkg/api/server/changestate.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+)
+
+// State values accepted by ChangeState.
+const (
+	StatePowerOn   = "power_on"
+	StatePowerOff  = "power_off"
+	StateRescueOn  = "rescue_on"
+	StateRescueOff = "rescue_off"
+	StateReboot    = "reboot"
+)
+
+// ChangeState transitions a server's power / rescue state via
+// "server/change_state.json". Both Name and State are required;
+// State must be one of the State* constants. Returns the
+// scheduler job for the state-change task.
+//
+// **This is destructive.** Power-off and reboot interrupt
+// running workloads on the server.
+func (s *Client) ChangeState(ctx context.Context, opt ChangeStateOptions) (response ChangeStateResponse, err error) {
+	if opt.Name == "" {
+		return response, fmt.Errorf("server.ChangeState: Name is required")
+	}
+	if opt.State == "" {
+		return response, fmt.Errorf("server.ChangeState: State is required (one of power_on/power_off/rescue_on/rescue_off/reboot)")
+	}
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "server/change_state.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/server/delete.go
+++ b/pkg/api/server/delete.go
@@ -13,14 +13,9 @@ import (
 // Every fresh Cloud Container Server auto-deploys an `infra` stack
 // (collectd, nginx-proxy, Let's Encrypt companion). Plain delete
 // rejects with "the server has containers" because the infra
-// stack is still present. The fix is to add `force_delete=1` to
-// the request body, which tears down the infra stack and the
-// server in one go.
-//
-// This base wrapper sends only `client_id` and `name`. Tearing
-// down a fresh CCS therefore requires assembling the form body
-// directly with `force_delete=1` until a Force field is added to
-// DeleteRequest in a follow-up.
+// stack is still present. Set DeleteRequest.Force to true to add
+// `force_delete=1` to the request body, which tears down the
+// infra stack and the server in one go.
 //
 // **Cannot delete while in 'Upgrading' state.** If a recent
 // server.Upgrade (plan upgrade) has just been issued, Delete is
@@ -38,6 +33,10 @@ func (s *Client) Delete(ctx context.Context, request DeleteRequest) (response De
 	values := url.Values{}
 	values.Add("client_id", s.client.ClientID)
 	values.Add("name", request.Name)
+	if request.Force {
+		values.Add("force_delete", "1")
+		keys = append(keys, "force_delete")
+	}
 
 	req, err := s.client.NewRequest("POST", u, net.Encode(values, keys))
 	if err != nil {

--- a/pkg/api/server/delete.go
+++ b/pkg/api/server/delete.go
@@ -17,11 +17,10 @@ import (
 // the request body, which tears down the infra stack and the
 // server in one go.
 //
-// This base wrapper sends only `client_id` and `name`. The Force
-// field on DeleteRequest (added in a later branch) appends
-// `force_delete=1` when set; until that lands here, examples that
-// need to tear down a fresh CCS send the form-body raw — see
-// examples/probe-tls-default and examples/server-upgrade-components.
+// This base wrapper sends only `client_id` and `name`. Tearing
+// down a fresh CCS therefore requires assembling the form body
+// directly with `force_delete=1` until a Force field is added to
+// DeleteRequest in a follow-up.
 //
 // **Cannot delete while in 'Upgrading' state.** If a recent
 // server.Upgrade (plan upgrade) has just been issued, Delete is

--- a/pkg/api/server/delete.go
+++ b/pkg/api/server/delete.go
@@ -7,7 +7,27 @@ import (
 	"github.com/sitehostnz/gosh/pkg/net"
 )
 
-// Delete a server with the provided name.
+// Delete a server with the provided name via /server/delete.json.
+//
+// **Fresh CCSes need `force_delete=1` (verified live, May 2026).**
+// Every fresh Cloud Container Server auto-deploys an `infra` stack
+// (collectd, nginx-proxy, Let's Encrypt companion). Plain delete
+// rejects with "the server has containers" because the infra
+// stack is still present. The fix is to add `force_delete=1` to
+// the request body, which tears down the infra stack and the
+// server in one go.
+//
+// This base wrapper sends only `client_id` and `name`. The Force
+// field on DeleteRequest (added in a later branch) appends
+// `force_delete=1` when set; until that lands here, examples that
+// need to tear down a fresh CCS send the form-body raw — see
+// examples/probe-tls-default and examples/server-upgrade-components.
+//
+// **Cannot delete while in 'Upgrading' state.** If a recent
+// server.Upgrade (plan upgrade) has just been issued, Delete is
+// rejected with "The specified server cannot be deleted while in
+// the 'Upgrading' state." Poll server.Get(name) until State is
+// On or Off before issuing Delete.
 func (s *Client) Delete(ctx context.Context, request DeleteRequest) (response DeleteResponse, err error) {
 	u := "server/delete.json"
 

--- a/pkg/api/server/doc.go
+++ b/pkg/api/server/doc.go
@@ -1,2 +1,50 @@
-// Package server represents our SiteHost `/server` API endpoint.
+// Package server wraps the SiteHost /server API endpoints — the
+// VPS / Cloud Container Server lifecycle: provision, get, list,
+// upgrade, snapshot, etc.
+//
+// # IP allocation when provisioning a new server
+//
+// Provisioning via Create requires an IPv4 (and optionally IPv6).
+// There are three paths consumers should know about — the API
+// docs only fully describe the first, so this package-level note
+// captures all three for AI agents and humans reading the SDK:
+//
+//  1. **Auto-allocation (recommended for most cases).** Set
+//     CreateRequest.Params.IPv4 to []string{"auto"} (and likewise
+//     IPv6 if you want one). The platform picks a free address
+//     from the location's pool and binds it to the new server.
+//     The public docs explicitly recommend this:
+//     "simply pass the string 'auto' to automatically assign
+//     an IPv4 address."
+//
+//  2. **Specific pre-allocated address.** Pass the address(es)
+//     directly, e.g. []string{"203.0.113.10"}. The address must
+//     **already be allocated to the calling client_id** — the
+//     platform won't transfer pool IPs into your client at
+//     provision time via this path.
+//
+//     ListIPs(location) returns the IPs **currently allocated to
+//     this client** at that location — *not* the location's free
+//     pool. If ListIPs returns an empty slice, that does **not**
+//     mean the pool is exhausted; it means this client has no
+//     allocations there. Use ListLocations to read pool-wide
+//     capacity (`AvailableIPs`, `AvailableIPv4`, `AvailableIPv6`).
+//
+//     Pitfall: a previous gosh session burned ~30 minutes
+//     retrying provisions because ListIPs returned [] and the
+//     wrapper's error message implied "no free IPs in the pool"
+//     — but the pool had hundreds free; the right fix was to
+//     pass `auto` instead. Don't waste cycles re-discovering
+//     this.
+//
+//  3. **Manual allocation by SiteHost staff.** Reseller-style
+//     arrangements may have IPs reserved for a client by
+//     SiteHost ops; once allocated they're visible via ListIPs
+//     and can be passed via path (2). Out of band relative to
+//     the SDK.
+//
+// **Default to path (1) unless you have a reason not to.** If you
+// do need a specific address, sanity-check via ListIPs first; if
+// that returns empty, fall back to "auto" rather than retrying or
+// concluding the pool is dry.
 package server

--- a/pkg/api/server/generatenetworkconfig.go
+++ b/pkg/api/server/generatenetworkconfig.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"context"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// GenerateNetworkConfig retrieves the network configuration files
+// for a server (returned as a path → file-contents map) via
+// "server/generate_network_config.json".
+func (s *Client) GenerateNetworkConfig(ctx context.Context, opt GenerateNetworkConfigOptions) (response GenerateNetworkConfigResponse, err error) {
+	u := "server/generate_network_config.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/server/generatenetworkconfig_test.go
+++ b/pkg/api/server/generatenetworkconfig_test.go
@@ -11,13 +11,16 @@ import (
 	"github.com/sitehostnz/gosh/pkg/api"
 )
 
+const testName = "ch-foo"
+
 func TestGenerateNetworkConfig_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/server/generate_network_config.json" {
 			t.Errorf("path = %q, want /server/generate_network_config.json", r.URL.Path)
 		}
-		if got := r.URL.Query().Get("name"); got != "ch-foo" {
-			t.Errorf("name = %q, want ch-foo", got)
+		if got := r.URL.Query().Get("name"); got != testName {
+			t.Errorf("name = %q, want %s", got, testName)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{
@@ -35,7 +38,7 @@ func TestGenerateNetworkConfig_Success(t *testing.T) {
 		t.Fatalf("api.New: %v", err)
 	}
 
-	got, err := New(c).GenerateNetworkConfig(context.Background(), GenerateNetworkConfigOptions{Name: "ch-foo"})
+	got, err := New(c).GenerateNetworkConfig(context.Background(), GenerateNetworkConfigOptions{Name: testName})
 	if err != nil {
 		t.Fatalf("GenerateNetworkConfig: %v", err)
 	}
@@ -47,11 +50,4 @@ func TestGenerateNetworkConfig_Success(t *testing.T) {
 	if !strings.Contains(cfg, "network:") {
 		t.Errorf("config does not contain 'network:': %q", cfg[:min(60, len(cfg))])
 	}
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/pkg/api/server/generatenetworkconfig_test.go
+++ b/pkg/api/server/generatenetworkconfig_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestGenerateNetworkConfig_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/server/generate_network_config.json" {
+			t.Errorf("path = %q, want /server/generate_network_config.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("name"); got != "ch-foo" {
+			t.Errorf("name = %q, want ch-foo", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful",
+			"return": {
+				"/etc/netplan/50-cloud-init.yaml": "network:\n    version: 2\n    ethernets:\n        eth0:\n            addresses:\n                - 198.51.100.10/24\n"
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).GenerateNetworkConfig(context.Background(), GenerateNetworkConfigOptions{Name: "ch-foo"})
+	if err != nil {
+		t.Fatalf("GenerateNetworkConfig: %v", err)
+	}
+
+	cfg, ok := got.Return["/etc/netplan/50-cloud-init.yaml"]
+	if !ok {
+		t.Fatal("expected netplan config in Return map")
+	}
+	if !strings.Contains(cfg, "network:") {
+		t.Errorf("config does not contain 'network:': %q", cfg[:min(60, len(cfg))])
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/api/server/getstate.go
+++ b/pkg/api/server/getstate.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"context"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// GetState retrieves the runtime state of a server (on/off/rescue
+// mode and the most recent job affecting it) via
+// "server/get_state.json".
+func (s *Client) GetState(ctx context.Context, opt GetStateOptions) (response GetStateResponse, err error) {
+	u := "server/get_state.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/server/getstate_test.go
+++ b/pkg/api/server/getstate_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestGetState_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("method = %q, want GET", r.Method)

--- a/pkg/api/server/getstate_test.go
+++ b/pkg/api/server/getstate_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestGetState_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/server/get_state.json" {
+			t.Errorf("path = %q, want /server/get_state.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("name"); got != "ch-foo" {
+			t.Errorf("name = %q, want ch-foo", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful",
+			"return": {
+				"state": "On",
+				"rescue": false,
+				"last_job": {"id": "29426222", "type": "scheduler", "state": "Complete"}
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).GetState(context.Background(), GetStateOptions{Name: "ch-foo"})
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+
+	if got.Return.State != "On" {
+		t.Errorf("State = %q, want On", got.Return.State)
+	}
+	if got.Return.Rescue {
+		t.Errorf("Rescue = true, want false")
+	}
+	if got.Return.LastJob.ID != "29426222" {
+		t.Errorf("LastJob.ID = %q, want 29426222", got.Return.LastJob.ID)
+	}
+	if got.Return.LastJob.State != "Complete" {
+		t.Errorf("LastJob.State = %q, want Complete", got.Return.LastJob.State)
+	}
+}

--- a/pkg/api/server/getstatistics.go
+++ b/pkg/api/server/getstatistics.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"context"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// GetStatistics returns the metric values for the named server.
+// Use ListStatisticTypes to enumerate the metric types available.
+//
+// Note: the parameter is "server_name" (not "name"), matching
+// ListStatisticTypes — this is an API-side inconsistency relative
+// to GetState/ListUpgrades/etc. on the same package.
+func (s *Client) GetStatistics(ctx context.Context, opt GetStatisticsOptions) (response GetStatisticsResponse, err error) {
+	u := "server/get_statistics.json"
+	keys := []string{"apikey", "client_id", "server_name"}
+
+	req, err := s.client.NewRequest("GET", u, "")
+	if err != nil {
+		return response, err
+	}
+	v := req.URL.Query()
+	v.Add("server_name", opt.ServerName)
+	req.URL.RawQuery = net.Encode(v, keys)
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/server/listallocatedips.go
+++ b/pkg/api/server/listallocatedips.go
@@ -1,0 +1,23 @@
+package server
+
+import "context"
+
+// ListAllocatedIPs returns the IP addresses allocated to the
+// authenticated client across the SiteHost network, keyed by a
+// dotted form of the IP address (IPv4 dots preserved; IPv6 colons
+// replaced with dots, double-colon with double-dot).
+//
+// The endpoint URL is "server/list_allocated_i_ps.json" — note the
+// underscore between "i" and "ps". This is the canonical name on
+// the API; using "list_allocated_ips" returns "method does not exist."
+func (s *Client) ListAllocatedIPs(ctx context.Context) (response ListAllocatedIPsResponse, err error) {
+	u := "server/list_allocated_i_ps.json"
+	req, err := s.client.NewRequest("GET", u, "")
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/server/listallocatedips.go
+++ b/pkg/api/server/listallocatedips.go
@@ -9,7 +9,7 @@ import "context"
 //
 // The endpoint URL is "server/list_allocated_i_ps.json" — note the
 // underscore between "i" and "ps". This is the canonical name on
-// the API; using "list_allocated_ips" returns "method does not exist."
+// the API; using "list_allocated_ips" returns "method does not exist".
 func (s *Client) ListAllocatedIPs(ctx context.Context) (response ListAllocatedIPsResponse, err error) {
 	u := "server/list_allocated_i_ps.json"
 	req, err := s.client.NewRequest("GET", u, "")

--- a/pkg/api/server/listimages.go
+++ b/pkg/api/server/listimages.go
@@ -1,0 +1,33 @@
+package server
+
+import "context"
+
+// ListImages retrieves the list of available server images via
+// "server/list_images.json".
+//
+// **Discoverability gap (verified live, May 2026):** this endpoint
+// returns only the older `ubuntu-<release>.amd64.cloud` salt-based
+// images (focal, xenial, trusty, etc.). The current Cloud
+// Container Server image codes — shaped like
+// `ubuntu-cc-<release>-<YYYYMMDD>` (e.g. `ubuntu-cc-2404-20260323`)
+// — are **not** returned here.
+//
+// Provisioning a CCS requires the cc-shaped code; pass it as the
+// Image field on server.CreateRequest. The current valid code can
+// only be discovered via SiteHost staff scheduler-table lookup or
+// empirically (running examples/probe-tls-default with a known
+// guess). See docs/open-api-questions.md "CCS image catalogue".
+func (s *Client) ListImages(ctx context.Context) (response ListImagesResponse, err error) {
+	u := "server/list_images.json"
+
+	req, err := s.client.NewRequest("GET", u, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/server/listimages_test.go
+++ b/pkg/api/server/listimages_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestListImages_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/server/list_images.json" {
 			t.Errorf("path = %q, want /server/list_images.json", r.URL.Path)

--- a/pkg/api/server/listimages_test.go
+++ b/pkg/api/server/listimages_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestListImages_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/server/list_images.json" {
+			t.Errorf("path = %q, want /server/list_images.json", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful",
+			"return": [
+				{"name": "Debian 13 (Trixie)", "code": "debian-trixie.amd64", "arch": "amd64", "distro": "debian-trixie", "type": "distro", "os": "linux"},
+				{"name": "Cloud Server (Trusty)", "code": "cloudhosting-v2-trusty", "arch": "amd64", "distro": "ubuntu-trusty", "type": "salt-container", "os": "linux"}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).ListImages(context.Background())
+	if err != nil {
+		t.Fatalf("ListImages: %v", err)
+	}
+
+	if len(got.Return) != 2 {
+		t.Fatalf("len(Return) = %d, want 2", len(got.Return))
+	}
+	if got.Return[0].Code != "debian-trixie.amd64" {
+		t.Errorf("Return[0].Code = %q, want debian-trixie.amd64", got.Return[0].Code)
+	}
+	if got.Return[0].Arch != "amd64" {
+		t.Errorf("Return[0].Arch = %q, want amd64", got.Return[0].Arch)
+	}
+}

--- a/pkg/api/server/listips.go
+++ b/pkg/api/server/listips.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"context"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// ListIPs returns the IP addresses available for new server
+// provisioning at the given location. Use ListLocations to
+// enumerate location codes.
+func (s *Client) ListIPs(ctx context.Context, opt ListIPsOptions) (response ListIPsResponse, err error) {
+	u := "server/list_ips.json"
+	keys := []string{"apikey", "client_id", "location"}
+
+	req, err := s.client.NewRequest("GET", u, "")
+	if err != nil {
+		return response, err
+	}
+	v := req.URL.Query()
+	v.Add("location", opt.Location)
+	req.URL.RawQuery = net.Encode(v, keys)
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/server/listlocations.go
+++ b/pkg/api/server/listlocations.go
@@ -1,0 +1,20 @@
+package server
+
+import "context"
+
+// ListLocations retrieves the list of datacenter locations available
+// for server provisioning via "server/list_locations.json".
+func (s *Client) ListLocations(ctx context.Context) (response ListLocationsResponse, err error) {
+	u := "server/list_locations.json"
+
+	req, err := s.client.NewRequest("GET", u, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/server/listlocations_test.go
+++ b/pkg/api/server/listlocations_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestListLocations_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/server/list_locations.json" {
+			t.Errorf("path = %q, want /server/list_locations.json", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful",
+			"return": [
+				{
+					"public": "1",
+					"os": ["Windows", "Linux"],
+					"label": "NZ - AKL01",
+					"code": "WINCITY",
+					"datacenter": "NZ-AKL1",
+					"available_ips": 183,
+					"available_ipv4": 39,
+					"available_ipv6": 144,
+					"ipv6": true,
+					"public_private_cloud": false,
+					"product_types": ["DISK", "UPGRAD", "VDSERV"]
+				}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).ListLocations(context.Background())
+	if err != nil {
+		t.Fatalf("ListLocations: %v", err)
+	}
+
+	if len(got.Return) != 1 {
+		t.Fatalf("len(Return) = %d, want 1", len(got.Return))
+	}
+	loc := got.Return[0]
+	if loc.Code != "WINCITY" {
+		t.Errorf("Code = %q, want WINCITY", loc.Code)
+	}
+	if loc.AvailableIPs != 183 {
+		t.Errorf("AvailableIPs = %d, want 183", loc.AvailableIPs)
+	}
+	if !loc.IPv6 {
+		t.Errorf("IPv6 = false, want true")
+	}
+	if len(loc.ProductTypes) != 3 {
+		t.Errorf("len(ProductTypes) = %d, want 3", len(loc.ProductTypes))
+	}
+}

--- a/pkg/api/server/listlocations_test.go
+++ b/pkg/api/server/listlocations_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestListLocations_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/server/list_locations.json" {
 			t.Errorf("path = %q, want /server/list_locations.json", r.URL.Path)

--- a/pkg/api/server/listresources.go
+++ b/pkg/api/server/listresources.go
@@ -1,0 +1,23 @@
+package server
+
+import "context"
+
+// ListResources retrieves the per-client resource quota groups via
+// "server/list_resources.json". Each group contains one or more
+// quotas (e.g. VPS Disk Space, VPS Memory) with total / used /
+// available unit counts and the list of objects (servers) consuming
+// each quota.
+func (s *Client) ListResources(ctx context.Context) (response ListResourcesResponse, err error) {
+	u := "server/list_resources.json"
+
+	req, err := s.client.NewRequest("GET", u, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/server/listresources_test.go
+++ b/pkg/api/server/listresources_test.go
@@ -67,13 +67,76 @@ func TestListResources_Success(t *testing.T) {
 	if q.AttributeName != "VPS Disk Space" {
 		t.Errorf("AttributeName = %q, want VPS Disk Space", q.AttributeName)
 	}
-	if q.TotalUnits != "1424" {
-		t.Errorf("TotalUnits = %q, want 1424", q.TotalUnits)
+	if q.TotalUnits != 1424 {
+		t.Errorf("TotalUnits = %v, want 1424", q.TotalUnits)
 	}
 	if q.AvailableUnits != -100 {
 		t.Errorf("AvailableUnits = %d, want -100", q.AvailableUnits)
 	}
 	if len(q.Objects) != 2 {
 		t.Errorf("len(Objects) = %d, want 2", len(q.Objects))
+	}
+}
+
+// TestListResources_MixedNumberShapes locks down the polymorphic
+// used_units quirk: same-response mix of JSON-string (non-zero rows)
+// and JSON-number (zero rows). Same quirk as the parallel
+// /bandwidth/list_resources endpoint addressed in #43.
+func TestListResources_MixedNumberShapes(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful",
+			"return": [
+				{
+					"client_id": "1234",
+					"group_id": "1",
+					"group_name": "NZ - Linux Servers",
+					"quotas": [
+						{
+							"attribute_id": "1",
+							"attribute_name": "VPS Disk Space (used)",
+							"attribute_unit": "GB",
+							"attribute_type": "0",
+							"total_units": "1424",
+							"used_units": "783",
+							"available_units": 641,
+							"objects": []
+						},
+						{
+							"attribute_id": "2",
+							"attribute_name": "VPS Disk Space (zero)",
+							"attribute_unit": "GB",
+							"attribute_type": "0",
+							"total_units": "1424",
+							"used_units": 0,
+							"available_units": 1424,
+							"objects": []
+						}
+					]
+				}
+			]
+		}`)
+	}))
+	defer srv.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+	got, err := New(c).ListResources(context.Background())
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	if len(got.Return) != 1 || len(got.Return[0].Quotas) != 2 {
+		t.Fatalf("unexpected shape: %+v", got.Return)
+	}
+	if got.Return[0].Quotas[0].UsedUnits != 783 {
+		t.Errorf("Quotas[0].UsedUnits = %v, want 783", got.Return[0].Quotas[0].UsedUnits)
+	}
+	if got.Return[0].Quotas[1].UsedUnits != 0 {
+		t.Errorf("Quotas[1].UsedUnits = %v, want 0", got.Return[0].Quotas[1].UsedUnits)
 	}
 }

--- a/pkg/api/server/listresources_test.go
+++ b/pkg/api/server/listresources_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestListResources_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/server/list_resources.json" {
 			t.Errorf("path = %q, want /server/list_resources.json", r.URL.Path)

--- a/pkg/api/server/listresources_test.go
+++ b/pkg/api/server/listresources_test.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestListResources_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/server/list_resources.json" {
+			t.Errorf("path = %q, want /server/list_resources.json", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful",
+			"return": [
+				{
+					"client_id": "1234",
+					"group_id": "1",
+					"group_name": "NZ - Linux Servers",
+					"quotas": [
+						{
+							"attribute_id": "1",
+							"attribute_name": "VPS Disk Space",
+							"attribute_unit": "GB",
+							"attribute_type": "0",
+							"total_units": "1424",
+							"used_units": "1524",
+							"available_units": -100,
+							"objects": ["server-a", "server-b"]
+						}
+					]
+				}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).ListResources(context.Background())
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+
+	if len(got.Return) != 1 {
+		t.Fatalf("len(Return) = %d, want 1", len(got.Return))
+	}
+	g := got.Return[0]
+	if g.GroupName != "NZ - Linux Servers" {
+		t.Errorf("GroupName = %q, want NZ - Linux Servers", g.GroupName)
+	}
+	if len(g.Quotas) != 1 {
+		t.Fatalf("len(Quotas) = %d, want 1", len(g.Quotas))
+	}
+	q := g.Quotas[0]
+	if q.AttributeName != "VPS Disk Space" {
+		t.Errorf("AttributeName = %q, want VPS Disk Space", q.AttributeName)
+	}
+	if q.TotalUnits != "1424" {
+		t.Errorf("TotalUnits = %q, want 1424", q.TotalUnits)
+	}
+	if q.AvailableUnits != -100 {
+		t.Errorf("AvailableUnits = %d, want -100", q.AvailableUnits)
+	}
+	if len(q.Objects) != 2 {
+		t.Errorf("len(Objects) = %d, want 2", len(q.Objects))
+	}
+}

--- a/pkg/api/server/liststatistictypes.go
+++ b/pkg/api/server/liststatistictypes.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"context"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// ListStatisticTypes returns the metric types available for the
+// named server (passed to GetStatistics).
+//
+// Note: this endpoint uses "server_name" as the parameter, distinct
+// from sibling endpoints like GetState that use plain "name". The
+// distinction is at the API level — the wrapper just transmits.
+func (s *Client) ListStatisticTypes(ctx context.Context, opt ListStatisticTypesOptions) (response ListStatisticTypesResponse, err error) {
+	u := "server/list_statistic_types.json"
+	keys := []string{"apikey", "client_id", "server_name"}
+
+	req, err := s.client.NewRequest("GET", u, "")
+	if err != nil {
+		return response, err
+	}
+	v := req.URL.Query()
+	v.Add("server_name", opt.ServerName)
+	req.URL.RawQuery = net.Encode(v, keys)
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/server/listupgrades.go
+++ b/pkg/api/server/listupgrades.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"context"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// ListUpgrades retrieves the upgrade-availability information for a
+// server (current quota usage, available extra-disk pricing, and
+// per-slot disk upgrade options) via "server/list_upgrades.json".
+func (s *Client) ListUpgrades(ctx context.Context, opt ListUpgradesOptions) (response ListUpgradesResponse, err error) {
+	u := "server/list_upgrades.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/server/listupgrades_test.go
+++ b/pkg/api/server/listupgrades_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestListUpgrades_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/server/list_upgrades.json" {
 			t.Errorf("path = %q, want /server/list_upgrades.json", r.URL.Path)

--- a/pkg/api/server/listupgrades_test.go
+++ b/pkg/api/server/listupgrades_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestListUpgrades_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/server/list_upgrades.json" {
+			t.Errorf("path = %q, want /server/list_upgrades.json", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("name"); got != "ch-foo" {
+			t.Errorf("name = %q, want ch-foo", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true,
+			"msg": "Successful",
+			"return": {
+				"quota": {
+					"ram":   {"total": 38, "used": 38},
+					"disk":  {"total": 1424, "used": 1524},
+					"cores": {"total": 27, "used": 18}
+				},
+				"extra-disk": {"price": 2.5, "size": 5},
+				"disk": {
+					"scsi0": {"included": [50], "extra": [55, 60, 65]}
+				}
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	c, err := api.New("k", "1", api.SetBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	got, err := New(c).ListUpgrades(context.Background(), ListUpgradesOptions{Name: "ch-foo"})
+	if err != nil {
+		t.Fatalf("ListUpgrades: %v", err)
+	}
+
+	if got.Return.Quota.RAM.Total != 38 {
+		t.Errorf("Quota.RAM.Total = %d, want 38", got.Return.Quota.RAM.Total)
+	}
+	if got.Return.Quota.Cores.Used != 18 {
+		t.Errorf("Quota.Cores.Used = %d, want 18", got.Return.Quota.Cores.Used)
+	}
+	if got.Return.ExtraDisk.Price != 2.5 {
+		t.Errorf("ExtraDisk.Price = %v, want 2.5", got.Return.ExtraDisk.Price)
+	}
+	scsi0, ok := got.Return.Disk["scsi0"]
+	if !ok {
+		t.Fatal("Disk[scsi0] missing")
+	}
+	if len(scsi0.Extra) != 3 {
+		t.Errorf("Disk[scsi0].Extra len = %d, want 3", len(scsi0.Extra))
+	}
+}

--- a/pkg/api/server/number.go
+++ b/pkg/api/server/number.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// Number tolerates the server API's mixed JSON-string / JSON-number
+// serialisation of numeric fields. ResourceQuota.UsedUnits and
+// TotalUnits are the known cases: when usage is non-zero the value
+// arrives as a JSON string (`"783"`), when usage is zero it arrives
+// as a JSON number (`0`), within the same response. Mirrors
+// bandwidth.Number from PR #43, which surfaced the same quirk on
+// the parallel /bandwidth/list_resources endpoint.
+type Number float64
+
+// UnmarshalJSON accepts either a JSON string or JSON number.
+func (n *Number) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		v, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return err
+		}
+		*n = Number(v)
+		return nil
+	}
+	return json.Unmarshal(b, (*float64)(n))
+}

--- a/pkg/api/server/reads_extras_test.go
+++ b/pkg/api/server/reads_extras_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestListIPs_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/server/list_ips.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -45,6 +46,7 @@ func TestListIPs_Success(t *testing.T) {
 }
 
 func TestListAllocatedIPs_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Note the literal underscore in the path — list_allocated_i_ps.
 		if r.URL.Path != "/server/list_allocated_i_ps.json" {
@@ -80,6 +82,7 @@ func TestListAllocatedIPs_Success(t *testing.T) {
 }
 
 func TestListStatisticTypes_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/server/list_statistic_types.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -103,6 +106,7 @@ func TestListStatisticTypes_Success(t *testing.T) {
 }
 
 func TestGetStatistics_Success(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/server/get_statistics.json" {
 			t.Errorf("path = %q", r.URL.Path)

--- a/pkg/api/server/reads_extras_test.go
+++ b/pkg/api/server/reads_extras_test.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestListIPs_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/server/list_ips.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("location"); got != "AKLCITY" {
+			t.Errorf("location = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// The actual API returns objects, not bare strings —
+		// {ip_addr, prefix, family} per IP. The earlier
+		// `Return []string` shape silently dropped this.
+		_, _ = io.WriteString(w, `{
+			"status":true, "msg":"Successful",
+			"return":[
+				{"ip_addr":"203.0.113.1","prefix":32,"family":4},
+				{"ip_addr":"203.0.113.2","prefix":32,"family":4}
+			]}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).ListIPs(context.Background(), ListIPsOptions{Location: "AKLCITY"})
+	if err != nil {
+		t.Fatalf("ListIPs: %v", err)
+	}
+	if len(got.Return) != 2 {
+		t.Fatalf("len(Return) = %d", len(got.Return))
+	}
+	if got.Return[0].IPAddr != "203.0.113.1" || got.Return[0].Family != 4 {
+		t.Errorf("first entry = %+v", got.Return[0])
+	}
+}
+
+func TestListAllocatedIPs_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Note the literal underscore in the path — list_allocated_i_ps.
+		if r.URL.Path != "/server/list_allocated_i_ps.json" {
+			t.Errorf("path = %q (note literal underscore in i_ps)", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status":true, "msg":"Successful",
+			"return": {
+				"203.0.113.10": {"ip_addr":"203.0.113.10","netmask":"255.255.255.0","gateway":"203.0.113.1","location":"AKLCITY","type":"v4"},
+				"2403.7000.8000.c00..9b": {"ip_addr":"2403:7000:8000:c00::9b","netmask":"ffff:ffff:ffff:ffff::","gateway":"2403:7000:8000:c00::1","location":"AKLCITY","type":"v6"}
+			}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).ListAllocatedIPs(context.Background())
+	if err != nil {
+		t.Fatalf("ListAllocatedIPs: %v", err)
+	}
+	if len(got.Return) != 2 {
+		t.Fatalf("len(Return) = %d", len(got.Return))
+	}
+	v4, ok := got.Return["203.0.113.10"]
+	if !ok || v4.IPAddr != "203.0.113.10" || v4.Type != "v4" {
+		t.Errorf("v4 entry = %+v", v4)
+	}
+	v6, ok := got.Return["2403.7000.8000.c00..9b"]
+	if !ok || v6.IPAddr != "2403:7000:8000:c00::9b" {
+		t.Errorf("v6 entry IPAddr = %q (key form is dotted; value preserves the literal)", v6.IPAddr)
+	}
+}
+
+func TestListStatisticTypes_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/server/list_statistic_types.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("server_name"); got != "ch-test" {
+			t.Errorf("server_name = %q (note: not 'name')", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":["cpu","mem","disk"]}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).ListStatisticTypes(context.Background(), ListStatisticTypesOptions{ServerName: "ch-test"})
+	if err != nil {
+		t.Fatalf("ListStatisticTypes: %v", err)
+	}
+	if len(got.Return) != 3 {
+		t.Errorf("Return = %v", got.Return)
+	}
+}
+
+func TestGetStatistics_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/server/get_statistics.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("server_name"); got != "ch-test" {
+			t.Errorf("server_name = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"cpu":[1.0,2.0,3.0]}}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).GetStatistics(context.Background(), GetStatisticsOptions{ServerName: "ch-test"})
+	if err != nil {
+		t.Fatalf("GetStatistics: %v", err)
+	}
+	if got.Return["cpu"] == nil {
+		t.Errorf("Return['cpu'] missing; got %v", got.Return)
+	}
+}

--- a/pkg/api/server/removeip.go
+++ b/pkg/api/server/removeip.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+)
+
+// RemoveIP removes an IP address from a server via
+// "server/remove_ip.json". Both Name and IP are required.
+// Returns the scheduler job and the IP that was removed.
+func (s *Client) RemoveIP(ctx context.Context, opt RemoveIPOptions) (response IPJobResponse, err error) {
+	if opt.Name == "" {
+		return response, fmt.Errorf("server.RemoveIP: Name is required")
+	}
+	if opt.IP == "" {
+		return response, fmt.Errorf("server.RemoveIP: IP is required")
+	}
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "server/remove_ip.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/server/request.go
+++ b/pkg/api/server/request.go
@@ -11,10 +11,55 @@ type (
 		Name string `json:"name"`
 	}
 
-	// UpgradeRequest represents a request to upgrade a Server.
+	// UpgradeRequest represents a request to upgrade a Server's plan
+	// (product code). Wraps /server/upgrade_plan.json — note the
+	// historical method-name / endpoint-name mismatch.
 	UpgradeRequest struct {
 		Name string `json:"name"`
 		Plan string `json:"plan"`
+	}
+
+	// UpgradeComponentsRequest configures a hardware-component
+	// upgrade on a server via /server/upgrade.json. At least one of
+	// Cores / RAM / Disk should be set; passing zero / empty for all
+	// is a no-op.
+	//
+	// Disk is the upgrade path most consumers actually want — VPS
+	// products commonly grow disk independently of their plan, where
+	// Cores/RAM are tied to the product code. CCS products reject
+	// component upgrades entirely (use the Upgrade method against
+	// /server/upgrade_plan.json for CCS resizing instead).
+	UpgradeComponentsRequest struct {
+		Name  string `json:"name"`
+		Cores int    `json:"upgrade[cores],omitempty"`
+		// RAM is the new total RAM amount in GB, expressed as a
+		// string per the API's expectation (e.g. "8" or "16").
+		RAM string `json:"upgrade[ram],omitempty"`
+		// Disk maps each disk's label (the device name as the
+		// platform sees it) to the new total size in GB. The
+		// label varies by hypervisor / disk attachment type — Xen
+		// surfaces "xvda1" / "xvdb1", virtio surfaces "vda" /
+		// "vdb", SCSI / SATA surface "sda" / "scsi0", etc.
+		//
+		// **Don't hardcode a label.** The right value differs per
+		// server. Discover dynamically by reading server.Get's
+		// Partitions field — each Partition has a Name (the label
+		// the upgrade endpoint expects).
+		//
+		// API expectations confirmed by live probing:
+		//   - Passing a scalar: rejected with
+		//     "Please specify an array of disk upgrades."
+		//   - Passing array indexed by 0/1/...: rejected with
+		//     "Please specify a valid disk label." (the index has
+		//     to be a real device name, not a position number).
+		//   - Correct: keyed by the actual disk label, e.g.
+		//     `map[string]int{"xvda1": 80}` for Xen,
+		//     `map[string]int{"scsi0": 80}` for SCSI.
+		//
+		// The public docs example shows `upgrade[disk][0]=10` but
+		// the description text reveals the real form:
+		// `upgrade[disk][xvda1]=10` — the index is a device name.
+		Disk map[string]int `json:"upgrade[disk],omitempty"`
 	}
 
 	// UpdateRequest represents a request to update a Server.
@@ -38,14 +83,129 @@ type (
 		Params      ParamsOptions `json:"params"`
 	}
 
-	// ParamsOptions represents the additional parameters in the request to create a Server.
+	// ParamsOptions represents the additional parameters in the
+	// request to create a Server.
+	//
+	// # IP allocation paths
+	//
+	// IPv4 / IPv6 control how the new server gets its address(es).
+	// There are three paths consumers should know about:
+	//
+	//   1. **Auto-allocation (recommended for most cases).** Pass
+	//      []string{"auto"} for IPv4 and/or IPv6. The platform
+	//      picks a free address from the location's pool and binds
+	//      it to the new server. This is the path the public API
+	//      docs explicitly recommend ("simply pass the string
+	//      'auto' to automatically assign an IPv4 address").
+	//
+	//   2. **Specific pre-allocated address.** Pass the address(es)
+	//      directly, e.g. []string{"203.0.113.10"}. The address
+	//      must already be allocated to the calling client_id —
+	//      the platform won't transfer pool IPs at provision time
+	//      this way. server.ListIPs(location) returns the IPs
+	//      currently allocated to the client; if it returns []
+	//      that does NOT mean the pool is exhausted, only that
+	//      this client has no allocations there. Use
+	//      server.ListLocations to read pool-wide capacity
+	//      (`available_ipv4`, `available_ipv6`).
+	//
+	//   3. **Manual allocation by SiteHost staff.** Reseller-style
+	//      arrangements may have IPs reserved for specific clients
+	//      via SiteHost ops, then accessed via path (2) once
+	//      visible in ListIPs. Out of band relative to the API.
+	//
+	// Don't conflate "ListIPs returned []" with "pool exhausted" —
+	// the wrapper's empty result almost always means "use 'auto'
+	// instead, or check ListLocations." A previous gosh session
+	// wasted ~30 minutes retrying because of this confusion.
 	ParamsOptions struct {
-		Name      string   `json:"name,omitempty"`
+		Name string `json:"name,omitempty"`
+		// IPv4 — see the IP-allocation paths section above. Most
+		// callers want []string{"auto"}.
 		IPv4      []string `json:"ipv4"`
 		IPv6      []string `json:"ipv6,omitempty"`
 		SSHKeys   []string `json:"ssh_keys,omitempty"`
 		ContactID string   `json:"contact_id,omitempty"`
 		Backup    string   `json:"backup,omitempty"`
 		SendEmail string   `json:"send_email,omitempty"`
+	}
+
+	// GetStateOptions represents request params for the get_state
+	// endpoint.
+	GetStateOptions struct {
+		Name string `url:"name"`
+	}
+
+	// ListUpgradesOptions represents request params for the
+	// list_upgrades endpoint.
+	ListUpgradesOptions struct {
+		Name string `url:"name"`
+	}
+
+	// GenerateNetworkConfigOptions represents request params for the
+	// generate_network_config endpoint.
+	GenerateNetworkConfigOptions struct {
+		Name string `url:"name"`
+	}
+
+	// AddIPOptions describes an IP address to add to a server.
+	// The API uses "param" (not "address") for the IP value.
+	AddIPOptions struct {
+		Name string `url:"name"`
+		IP   string `url:"param"`
+	}
+
+	// RemoveIPOptions describes an IP address to remove from a
+	// server. The API uses "address" here (distinct from add_ip's
+	// "param") — the inconsistency is the API's, not gosh's.
+	RemoveIPOptions struct {
+		Name string `url:"name"`
+		IP   string `url:"address"`
+	}
+
+	// SetPrimaryIPOptions describes the new primary IP for a
+	// server. Uses "address" like remove_ip.
+	SetPrimaryIPOptions struct {
+		Name string `url:"name"`
+		IP   string `url:"address"`
+	}
+
+	// ChangeStateOptions describes a server state transition.
+	// Valid State values: "power_on", "power_off", "rescue_on",
+	// "rescue_off", "reboot".
+	ChangeStateOptions struct {
+		Name  string `url:"name"`
+		State string `url:"state"`
+	}
+
+	// CanProvisionOptions checks resource availability for
+	// provisioning a server. Product, Location, and Distro are
+	// required; Arch is optional.
+	CanProvisionOptions struct {
+		Product  string `url:"product"`
+		Location string `url:"location"`
+		Distro   string `url:"distro"`
+		Arch     string `url:"arch,omitempty"`
+	}
+
+	// ListIPsOptions identifies the location whose available IPs
+	// to list. The Location field maps to the API's "location"
+	// parameter (a location code from server.ListLocations).
+	ListIPsOptions struct {
+		Location string `url:"location"`
+	}
+
+	// ListStatisticTypesOptions identifies the server whose metric
+	// types to enumerate. The parameter is "server_name" — distinct
+	// from siblings that use plain "name".
+	ListStatisticTypesOptions struct {
+		ServerName string `url:"server_name"`
+	}
+
+	// GetStatisticsOptions identifies the server whose metric values
+	// to fetch. Like ListStatisticTypesOptions, the parameter is
+	// "server_name".
+	GetStatisticsOptions struct {
+		ServerName string `url:"server_name"`
 	}
 )

--- a/pkg/api/server/request.go
+++ b/pkg/api/server/request.go
@@ -7,8 +7,15 @@ type (
 	}
 
 	// DeleteRequest represents a request to delete a Server.
+	//
+	// Force, when set, appends `force_delete=1` to the form body.
+	// Required to tear down a fresh CCS that still has its
+	// auto-deployed `infra` stack present (collectd, nginx-proxy,
+	// LE companion); without Force the API rejects with "the
+	// server has containers." See the doc comment on Delete.
 	DeleteRequest struct {
-		Name string `json:"name"`
+		Name  string `json:"name"`
+		Force bool   `json:"-"`
 	}
 
 	// UpgradeRequest represents a request to upgrade a Server's plan
@@ -149,10 +156,37 @@ type (
 	}
 
 	// AddIPOptions describes an IP address to add to a server.
-	// The API uses "param" (not "address") for the IP value.
+	//
+	// Set exactly one of IP or IPVersion:
+	//
+	//   - IP: a real IPv4 or IPv6 address already allocated to the
+	//     calling client_id.
+	//   - IPVersion: 4 or 6 to auto-allocate a free address of that
+	//     family from the location's pool.
+	//
+	// At the wire level the API takes a single `param` field whose
+	// value is either the address or the family number — that
+	// magic-string convention is awkward to expose, so the wrapper
+	// splits it into two typed fields and assembles `param` itself.
+	//
+	// Note: "auto" works on Create but is rejected here. The two
+	// endpoints use different conventions:
+	//
+	//   - Create: params[ipv4][0]=auto (string "auto")
+	//   - AddIP:  param=4 or param=6   (family number)
+	//
+	// Live evidence (May 2026): AddIP{IP:"auto"} returns
+	// "Error: The ip address is invalid, please specify a valid
+	// ip address." AddIP{IPVersion:4} successfully allocates an
+	// IPv4 from the pool; AddIP{IPVersion:6} an IPv6.
+	//
+	// The API uses "param" (not "address") for this field — the
+	// inconsistency with RemoveIPOptions ("address") is the API's,
+	// not gosh's.
 	AddIPOptions struct {
-		Name string `url:"name"`
-		IP   string `url:"param"`
+		Name      string `url:"name"`
+		IP        string `url:"-"`
+		IPVersion int    `url:"-"`
 	}
 
 	// RemoveIPOptions describes an IP address to remove from a

--- a/pkg/api/server/response.go
+++ b/pkg/api/server/response.go
@@ -19,6 +19,20 @@ type (
 		models.APIResponse
 	}
 
+	// UpgradeComponentsResponse represents a result of an
+	// /server/upgrade.json call. Returns a scheduler job plus
+	// per-component bool flags indicating which upgrades were
+	// accepted (true) versus rejected (false / missing).
+	UpgradeComponentsResponse struct {
+		Return struct {
+			models.Job `json:"job"`
+			Cores      bool `json:"cores"`
+			RAM        bool `json:"ram"`
+			Disk       bool `json:"disk"`
+		} `json:"return"`
+		models.APIResponse
+	}
+
 	// CreateResponse represents a result of the create a Server call.
 	CreateResponse struct {
 		Return struct {
@@ -53,6 +67,229 @@ type (
 
 	// UpgradeResponse represents a result of a upgrade Server call.
 	UpgradeResponse struct {
+		models.APIResponse
+	}
+
+	// LastJob is a brief summary of the most recent job affecting a
+	// server, returned by get_state.
+	LastJob struct {
+		ID    string `json:"id"`
+		Type  string `json:"type"`
+		State string `json:"state"`
+	}
+
+	// ServerState is the runtime state of a server.
+	ServerState struct {
+		State   string  `json:"state"`
+		Rescue  bool    `json:"rescue"`
+		LastJob LastJob `json:"last_job"`
+	}
+
+	// GetStateResponse represents the response from get_state.
+	GetStateResponse struct {
+		Return ServerState `json:"return"`
+		models.APIResponse
+	}
+
+	// Image is a server image entry from list_images.
+	Image struct {
+		Name   string `json:"name"`
+		Code   string `json:"code"`
+		Arch   string `json:"arch"`
+		Distro string `json:"distro"`
+		Type   string `json:"type"`
+		OS     string `json:"os"`
+	}
+
+	// ListImagesResponse represents the response from list_images.
+	ListImagesResponse struct {
+		Return []Image `json:"return"`
+		models.APIResponse
+	}
+
+	// Location is a datacenter location entry from list_locations.
+	// Public is returned as a string flag ("0"/"1") by the API.
+	Location struct {
+		Public             string   `json:"public"`
+		OS                 []string `json:"os"`
+		Label              string   `json:"label"`
+		Code               string   `json:"code"`
+		Datacenter         string   `json:"datacenter"`
+		AvailableIPs       int      `json:"available_ips"`
+		AvailableIPv4      int      `json:"available_ipv4"`
+		AvailableIPv6      int      `json:"available_ipv6"`
+		IPv6               bool     `json:"ipv6"`
+		PublicPrivateCloud bool     `json:"public_private_cloud"`
+		ProductTypes       []string `json:"product_types"`
+	}
+
+	// ListLocationsResponse represents the response from list_locations.
+	ListLocationsResponse struct {
+		Return []Location `json:"return"`
+		models.APIResponse
+	}
+
+	// ResourceQuota is a single quota entry inside a resource group.
+	// TotalUnits and UsedUnits are returned as strings; AvailableUnits
+	// is returned as a number (and may be negative when over-quota).
+	ResourceQuota struct {
+		AttributeID    string   `json:"attribute_id"`
+		AttributeName  string   `json:"attribute_name"`
+		AttributeUnit  string   `json:"attribute_unit"`
+		AttributeType  string   `json:"attribute_type"`
+		TotalUnits     string   `json:"total_units"`
+		UsedUnits      string   `json:"used_units"`
+		AvailableUnits int      `json:"available_units"`
+		Objects        []string `json:"objects"`
+	}
+
+	// ResourceGroup represents a per-client resource quota group from
+	// list_resources.
+	ResourceGroup struct {
+		ClientID  string          `json:"client_id"`
+		GroupID   string          `json:"group_id"`
+		GroupName string          `json:"group_name"`
+		Quotas    []ResourceQuota `json:"quotas"`
+	}
+
+	// ListResourcesResponse represents the response from list_resources.
+	ListResourcesResponse struct {
+		Return []ResourceGroup `json:"return"`
+		models.APIResponse
+	}
+
+	// QuotaUsage is a total/used pair returned within UpgradeQuota.
+	QuotaUsage struct {
+		Total int `json:"total"`
+		Used  int `json:"used"`
+	}
+
+	// UpgradeQuota is the overall quota / usage block from list_upgrades.
+	UpgradeQuota struct {
+		RAM   QuotaUsage `json:"ram"`
+		Disk  QuotaUsage `json:"disk"`
+		Cores QuotaUsage `json:"cores"`
+	}
+
+	// ExtraDiskOption is the per-unit price/size offered for additional
+	// disk capacity.
+	ExtraDiskOption struct {
+		Price float64 `json:"price"`
+		Size  int     `json:"size"`
+	}
+
+	// DiskUpgradeOptions is the per-disk-slot list of included and
+	// available extra disk sizes.
+	DiskUpgradeOptions struct {
+		Included []int `json:"included"`
+		Extra    []int `json:"extra"`
+	}
+
+	// Upgrades is the upgrade-availability information for a server.
+	// The Disk map is keyed by disk slot identifier (e.g. "scsi0").
+	Upgrades struct {
+		Quota     UpgradeQuota                  `json:"quota"`
+		ExtraDisk ExtraDiskOption               `json:"extra-disk"`
+		Disk      map[string]DiskUpgradeOptions `json:"disk"`
+	}
+
+	// ListUpgradesResponse represents the response from list_upgrades.
+	ListUpgradesResponse struct {
+		Return Upgrades `json:"return"`
+		models.APIResponse
+	}
+
+	// GenerateNetworkConfigResponse represents the response from
+	// generate_network_config. The Return map is keyed by file path
+	// (e.g. "/etc/netplan/50-cloud-init.yaml") with file contents
+	// as the value.
+	GenerateNetworkConfigResponse struct {
+		Return map[string]string `json:"return"`
+		models.APIResponse
+	}
+
+	// IPJobResponse represents the shared response from add_ip and
+	// remove_ip — a scheduler job plus the IP address that was
+	// affected.
+	IPJobResponse struct {
+		Return struct {
+			models.Job `json:"job"`
+			IPAddr     string `json:"ip_addr"`
+		} `json:"return"`
+		models.APIResponse
+	}
+
+	// SetPrimaryIPResponse represents the synchronous response
+	// from set_primary_ip.
+	SetPrimaryIPResponse struct {
+		Return struct {
+			IPAddr string `json:"ip_addr"`
+		} `json:"return"`
+		models.APIResponse
+	}
+
+	// ChangeStateResponse represents the response from
+	// change_state — a scheduler job for the state transition.
+	ChangeStateResponse struct {
+		Return struct {
+			models.Job `json:"job"`
+		} `json:"return"`
+		models.APIResponse
+	}
+
+	// AvailableIP is a single IP entry from server.list_ips. The
+	// API returns objects, not strings — earlier versions of this
+	// wrapper had `Return []string` which silently dropped the
+	// per-IP shape.
+	AvailableIP struct {
+		IPAddr string `json:"ip_addr"`
+		Prefix int    `json:"prefix"`
+		Family int    `json:"family"` // 4 for IPv4, 6 for IPv6
+	}
+
+	// ListIPsResponse is the response for server.list_ips. The
+	// Return slice lists IPs available for new provisioning at the
+	// given location; empty when none are free.
+	ListIPsResponse struct {
+		Return []AvailableIP `json:"return"`
+		models.APIResponse
+	}
+
+	// AllocatedIP describes one IP currently allocated to the
+	// authenticated client, as returned by list_allocated_i_ps.
+	AllocatedIP struct {
+		IPAddr   string `json:"ip_addr"`
+		Netmask  string `json:"netmask"`
+		Gateway  string `json:"gateway"`
+		Location string `json:"location"`
+		Type     string `json:"type"` // "v4" or "v6"
+	}
+
+	// ListAllocatedIPsResponse is the response for
+	// list_allocated_i_ps. Return is a map keyed by a transformed IP
+	// string (IPv4 dots preserved; IPv6 colons replaced with dots,
+	// double-colon replaced with double-dot). The IPAddr field on
+	// each value carries the original IP literal.
+	ListAllocatedIPsResponse struct {
+		Return map[string]AllocatedIP `json:"return"`
+		models.APIResponse
+	}
+
+	// ListStatisticTypesResponse is the response for
+	// list_statistic_types. Return enumerates the metric type IDs
+	// the named server currently exposes.
+	ListStatisticTypesResponse struct {
+		Return []string `json:"return"`
+		models.APIResponse
+	}
+
+	// GetStatisticsResponse is the response for get_statistics. The
+	// Return shape is server-specific and time-windowed; consumers
+	// typically deserialise selectively from the raw JSON when
+	// looking at specific metrics. Captured here as a generic map
+	// to keep gosh's surface usable without schema-locking.
+	GetStatisticsResponse struct {
+		Return map[string]interface{} `json:"return"`
 		models.APIResponse
 	}
 )

--- a/pkg/api/server/response.go
+++ b/pkg/api/server/response.go
@@ -136,15 +136,20 @@ type (
 	}
 
 	// ResourceQuota is a single quota entry inside a resource group.
-	// TotalUnits and UsedUnits are returned as strings; AvailableUnits
-	// is returned as a number (and may be negative when over-quota).
+	// AvailableUnits is returned as a number (and may be negative
+	// when over-quota).
+	//
+	// TotalUnits and UsedUnits use [Number] because the API mixes
+	// JSON-string and JSON-number forms within a single response —
+	// see the [Number] type documentation. Same quirk as the
+	// parallel /bandwidth/list_resources endpoint addressed in #43.
 	ResourceQuota struct {
 		AttributeID    string   `json:"attribute_id"`
 		AttributeName  string   `json:"attribute_name"`
 		AttributeUnit  string   `json:"attribute_unit"`
 		AttributeType  string   `json:"attribute_type"`
-		TotalUnits     string   `json:"total_units"`
-		UsedUnits      string   `json:"used_units"`
+		TotalUnits     Number   `json:"total_units"`
+		UsedUnits      Number   `json:"used_units"`
 		AvailableUnits int      `json:"available_units"`
 		Objects        []string `json:"objects"`
 	}

--- a/pkg/api/server/response.go
+++ b/pkg/api/server/response.go
@@ -79,6 +79,8 @@ type (
 	}
 
 	// ServerState is the runtime state of a server.
+	//
+	//nolint:revive // name kept verbose for grep-from-API parity
 	ServerState struct {
 		State   string  `json:"state"`
 		Rescue  bool    `json:"rescue"`

--- a/pkg/api/server/response.go
+++ b/pkg/api/server/response.go
@@ -300,6 +300,13 @@ type (
 	}
 )
 
+// isEmptyMapShape reports whether the raw "return" payload is one of
+// the forms the API uses for an empty map: omitted/zero-length, JSON
+// null, or the empty array `[]` it serialises in place of `{}`.
+func isEmptyMapShape(raw json.RawMessage) bool {
+	return len(raw) == 0 || string(raw) == "null" || string(raw) == "[]"
+}
+
 // UnmarshalJSON tolerates the empty-array form the API returns when
 // the server has no generated network config rows.
 func (r *GenerateNetworkConfigResponse) UnmarshalJSON(data []byte) error {
@@ -312,7 +319,7 @@ func (r *GenerateNetworkConfigResponse) UnmarshalJSON(data []byte) error {
 	}
 	r.APIResponse = envelope.APIResponse
 	raw := envelope.Return
-	if len(raw) == 0 || string(raw) == "null" || string(raw) == "[]" {
+	if isEmptyMapShape(raw) {
 		r.Return = map[string]string{}
 		return nil
 	}
@@ -331,7 +338,7 @@ func (r *ListAllocatedIPsResponse) UnmarshalJSON(data []byte) error {
 	}
 	r.APIResponse = envelope.APIResponse
 	raw := envelope.Return
-	if len(raw) == 0 || string(raw) == "null" || string(raw) == "[]" {
+	if isEmptyMapShape(raw) {
 		r.Return = map[string]AllocatedIP{}
 		return nil
 	}
@@ -350,7 +357,7 @@ func (r *GetStatisticsResponse) UnmarshalJSON(data []byte) error {
 	}
 	r.APIResponse = envelope.APIResponse
 	raw := envelope.Return
-	if len(raw) == 0 || string(raw) == "null" || string(raw) == "[]" {
+	if isEmptyMapShape(raw) {
 		r.Return = map[string]interface{}{}
 		return nil
 	}

--- a/pkg/api/server/response.go
+++ b/pkg/api/server/response.go
@@ -1,6 +1,10 @@
 package server
 
-import "github.com/sitehostnz/gosh/pkg/models"
+import (
+	"encoding/json"
+
+	"github.com/sitehostnz/gosh/pkg/models"
+)
 
 type (
 	// DeleteResponse represents a result of a delete Server call.
@@ -295,3 +299,60 @@ type (
 		models.APIResponse
 	}
 )
+
+// UnmarshalJSON tolerates the empty-array form the API returns when
+// the server has no generated network config rows.
+func (r *GenerateNetworkConfigResponse) UnmarshalJSON(data []byte) error {
+	var envelope struct {
+		Return json.RawMessage `json:"return"`
+		models.APIResponse
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return err
+	}
+	r.APIResponse = envelope.APIResponse
+	raw := envelope.Return
+	if len(raw) == 0 || string(raw) == "null" || string(raw) == "[]" {
+		r.Return = map[string]string{}
+		return nil
+	}
+	return json.Unmarshal(raw, &r.Return)
+}
+
+// UnmarshalJSON tolerates the empty-array form the API returns when
+// the server has no allocated IPs.
+func (r *ListAllocatedIPsResponse) UnmarshalJSON(data []byte) error {
+	var envelope struct {
+		Return json.RawMessage `json:"return"`
+		models.APIResponse
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return err
+	}
+	r.APIResponse = envelope.APIResponse
+	raw := envelope.Return
+	if len(raw) == 0 || string(raw) == "null" || string(raw) == "[]" {
+		r.Return = map[string]AllocatedIP{}
+		return nil
+	}
+	return json.Unmarshal(raw, &r.Return)
+}
+
+// UnmarshalJSON tolerates the empty-array form the API returns when
+// no statistics are available for the requested interval.
+func (r *GetStatisticsResponse) UnmarshalJSON(data []byte) error {
+	var envelope struct {
+		Return json.RawMessage `json:"return"`
+		models.APIResponse
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return err
+	}
+	r.APIResponse = envelope.APIResponse
+	raw := envelope.Return
+	if len(raw) == 0 || string(raw) == "null" || string(raw) == "[]" {
+		r.Return = map[string]interface{}{}
+		return nil
+	}
+	return json.Unmarshal(raw, &r.Return)
+}

--- a/pkg/api/server/setprimaryip.go
+++ b/pkg/api/server/setprimaryip.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-querystring/query"
+)
+
+// SetPrimaryIP sets the primary IP address for a server via
+// "server/set_primary_ip.json". Both Name and IP are required.
+// Synchronous (no scheduler job); returns the new primary IP.
+func (s *Client) SetPrimaryIP(ctx context.Context, opt SetPrimaryIPOptions) (response SetPrimaryIPResponse, err error) {
+	if opt.Name == "" {
+		return response, fmt.Errorf("server.SetPrimaryIP: Name is required")
+	}
+	if opt.IP == "" {
+		return response, fmt.Errorf("server.SetPrimaryIP: IP is required")
+	}
+
+	values, err := query.Values(opt)
+	if err != nil {
+		return response, err
+	}
+	req, err := s.client.NewRequest("POST", "server/set_primary_ip.json", values.Encode())
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/server/snapshot/create.go
+++ b/pkg/api/server/snapshot/create.go
@@ -1,0 +1,46 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Create takes a new snapshot of a server's disk via
+// "server/snapshot/create.json". Name (the server), Partition
+// (disk slot, e.g. "scsi0"), and Lifetime (hours) are all required.
+// Returned JobResponse carries the scheduler job ID.
+func (s *Client) Create(ctx context.Context, opt CreateOptions) (response JobResponse, err error) {
+	if opt.Name == "" {
+		return response, fmt.Errorf("snapshot.Create: Name is required")
+	}
+	if opt.Partition == "" {
+		return response, fmt.Errorf("snapshot.Create: Partition is required")
+	}
+	if opt.Lifetime <= 0 {
+		return response, fmt.Errorf("snapshot.Create: Lifetime must be > 0")
+	}
+
+	u := "server/snapshot/create.json"
+
+	keys := []string{"client_id", "name", "partition", "lifetime"}
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("name", opt.Name)
+	values.Add("partition", opt.Partition)
+	values.Add("lifetime", strconv.Itoa(opt.Lifetime))
+
+	req, err := s.client.NewRequest("POST", u, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/server/snapshot/create_test.go
+++ b/pkg/api/server/snapshot/create_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestCreate_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method = %q", r.Method)
@@ -37,12 +38,13 @@ func TestCreate_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if got.Return.Job.ID != 29658457 {
-		t.Errorf("Job.ID = %d", got.Return.Job.ID)
+	if got.Return.ID != 29658457 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
 	}
 }
 
 func TestCreate_RequiredFields(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	if _, err := New(c).Create(context.Background(), CreateOptions{Partition: "scsi0", Lifetime: 1}); err == nil ||
 		!strings.Contains(err.Error(), "Name is required") {

--- a/pkg/api/server/snapshot/create_test.go
+++ b/pkg/api/server/snapshot/create_test.go
@@ -1,0 +1,59 @@
+package snapshot
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestCreate_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("partition"); got != "scsi0" {
+			t.Errorf("partition = %q", got)
+		}
+		if got := r.Form.Get("lifetime"); got != "24" {
+			t.Errorf("lifetime = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":29658457,"type":"scheduler"}}}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).Create(context.Background(), CreateOptions{
+		Name: "ch-foo", Partition: "scsi0", Lifetime: 24,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got.Return.Job.ID != 29658457 {
+		t.Errorf("Job.ID = %d", got.Return.Job.ID)
+	}
+}
+
+func TestCreate_RequiredFields(t *testing.T) {
+	c, _ := api.New("k", "1")
+	if _, err := New(c).Create(context.Background(), CreateOptions{Partition: "scsi0", Lifetime: 1}); err == nil ||
+		!strings.Contains(err.Error(), "Name is required") {
+		t.Errorf("missing Name: err = %v", err)
+	}
+	if _, err := New(c).Create(context.Background(), CreateOptions{Name: "n", Lifetime: 1}); err == nil ||
+		!strings.Contains(err.Error(), "Partition is required") {
+		t.Errorf("missing Partition: err = %v", err)
+	}
+	if _, err := New(c).Create(context.Background(), CreateOptions{Name: "n", Partition: "scsi0"}); err == nil ||
+		!strings.Contains(err.Error(), "Lifetime must be > 0") {
+		t.Errorf("missing Lifetime: err = %v", err)
+	}
+}

--- a/pkg/api/server/snapshot/delete.go
+++ b/pkg/api/server/snapshot/delete.go
@@ -1,0 +1,40 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Delete removes a snapshot via "server/snapshot/delete.json".
+// Both Name (the server) and Snapshot (the snapshot ID) are
+// required.
+func (s *Client) Delete(ctx context.Context, opt SnapshotOptions) (response JobResponse, err error) {
+	if opt.Name == "" {
+		return response, fmt.Errorf("snapshot.Delete: Name is required")
+	}
+	if opt.Snapshot == "" {
+		return response, fmt.Errorf("snapshot.Delete: Snapshot is required")
+	}
+
+	u := "server/snapshot/delete.json"
+
+	keys := []string{"client_id", "name", "snapshot"}
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("name", opt.Name)
+	values.Add("snapshot", opt.Snapshot)
+
+	req, err := s.client.NewRequest("POST", u, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/server/snapshot/delete_test.go
+++ b/pkg/api/server/snapshot/delete_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestDelete_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("ParseForm: %v", err)
@@ -31,6 +32,7 @@ func TestDelete_Success(t *testing.T) {
 }
 
 func TestDelete_RequiredFields(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	if _, err := New(c).Delete(context.Background(), SnapshotOptions{Snapshot: "1"}); err == nil ||
 		!strings.Contains(err.Error(), "Name is required") {

--- a/pkg/api/server/snapshot/delete_test.go
+++ b/pkg/api/server/snapshot/delete_test.go
@@ -1,0 +1,43 @@
+package snapshot
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestDelete_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("snapshot"); got != "91695" {
+			t.Errorf("snapshot = %q (note: not snapshot_id)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":1,"type":"scheduler"}}}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	if _, err := New(c).Delete(context.Background(), SnapshotOptions{Name: "ch-foo", Snapshot: "91695"}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestDelete_RequiredFields(t *testing.T) {
+	c, _ := api.New("k", "1")
+	if _, err := New(c).Delete(context.Background(), SnapshotOptions{Snapshot: "1"}); err == nil ||
+		!strings.Contains(err.Error(), "Name is required") {
+		t.Errorf("missing Name: err = %v", err)
+	}
+	if _, err := New(c).Delete(context.Background(), SnapshotOptions{Name: "n"}); err == nil ||
+		!strings.Contains(err.Error(), "Snapshot is required") {
+		t.Errorf("missing Snapshot: err = %v", err)
+	}
+}

--- a/pkg/api/server/snapshot/doc.go
+++ b/pkg/api/server/snapshot/doc.go
@@ -1,0 +1,4 @@
+// Package snapshot represents our SiteHost `/server/snapshot` API
+// endpoint — server-level disk snapshot management (list, create,
+// delete, restore, lifetime).
+package snapshot

--- a/pkg/api/server/snapshot/listall.go
+++ b/pkg/api/server/snapshot/listall.go
@@ -1,0 +1,34 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// List retrieves all snapshots for the specified server via
+// "server/snapshot/list_all.json". Name is required.
+func (s *Client) List(ctx context.Context, opt ListOptions) (response ListResponse, err error) {
+	if opt.Name == "" {
+		return response, fmt.Errorf("snapshot.List: Name is required")
+	}
+
+	u := "server/snapshot/list_all.json"
+
+	path, err := net.AddOptions(u, opt)
+	if err != nil {
+		return response, err
+	}
+
+	req, err := s.client.NewRequest("GET", path, "")
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/server/snapshot/listall_test.go
+++ b/pkg/api/server/snapshot/listall_test.go
@@ -1,0 +1,69 @@
+package snapshot
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestList_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/server/snapshot/list_all.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("name"); got != "ch-foo" {
+			t.Errorf("name = %q (note: not server_name)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status": true, "msg": "Successful",
+			"return": [
+				{
+					"id": "91695", "name": "s-20260502135000",
+					"device": "s-20260502135000", "mountpoint": "",
+					"size": 0, "fstype": "raw", "drbd": "0", "parent": "90875",
+					"pending": "0", "created": "2026-05-02 13:50:00",
+					"backup": "0",
+					"disk_total": "0", "disk_used": "0",
+					"inodes_total": "0", "inodes_used": "0",
+					"stats_updated": "0000-00-00 00:00:00",
+					"disk_warn": "0", "is_missing": false,
+					"expires": "2026-05-02 14:50:00"
+				}
+			]
+		}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	got, err := New(c).List(context.Background(), ListOptions{Name: "ch-foo"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got.Return) != 1 {
+		t.Fatalf("len(Return) = %d, want 1", len(got.Return))
+	}
+	s := got.Return[0]
+	if s.ID != "91695" {
+		t.Errorf("ID = %q", s.ID)
+	}
+	if s.IsMissing {
+		t.Errorf("IsMissing = true, want false (real bool)")
+	}
+	if s.Pending != "0" {
+		t.Errorf("Pending = %q (string-typed)", s.Pending)
+	}
+}
+
+func TestList_NameRequired(t *testing.T) {
+	c, _ := api.New("k", "1")
+	if _, err := New(c).List(context.Background(), ListOptions{}); err == nil ||
+		!strings.Contains(err.Error(), "Name is required") {
+		t.Errorf("err = %v", err)
+	}
+}

--- a/pkg/api/server/snapshot/listall_test.go
+++ b/pkg/api/server/snapshot/listall_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestList_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/server/snapshot/list_all.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -61,6 +62,7 @@ func TestList_Success(t *testing.T) {
 }
 
 func TestList_NameRequired(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	if _, err := New(c).List(context.Background(), ListOptions{}); err == nil ||
 		!strings.Contains(err.Error(), "Name is required") {

--- a/pkg/api/server/snapshot/models.go
+++ b/pkg/api/server/snapshot/models.go
@@ -1,0 +1,18 @@
+package snapshot
+
+import (
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+type (
+	// Client is a Service to work with the SiteHost server
+	// snapshot API.
+	Client struct {
+		client *api.Client
+	}
+)
+
+// New is an initialisation function.
+func New(c *api.Client) *Client {
+	return &Client{client: c}
+}

--- a/pkg/api/server/snapshot/request.go
+++ b/pkg/api/server/snapshot/request.go
@@ -20,6 +20,8 @@ type (
 	// SnapshotOptions identifies a snapshot for the operations
 	// that act on a single snapshot (delete, restore). The server
 	// is identified by Name; the snapshot by Snapshot.
+	//
+	//nolint:revive // name kept verbose for grep-from-API parity
 	SnapshotOptions struct {
 		Name     string `url:"name"`
 		Snapshot string `url:"snapshot"`

--- a/pkg/api/server/snapshot/request.go
+++ b/pkg/api/server/snapshot/request.go
@@ -1,0 +1,35 @@
+package snapshot
+
+type (
+	// ListOptions identifies the server whose snapshots to list.
+	// Note the API uses the unprefixed parameter name "name" for
+	// the server identifier (not "server_name").
+	ListOptions struct {
+		Name string `url:"name"`
+	}
+
+	// CreateOptions describes a new snapshot to take. All fields
+	// are required: Name (the server), Partition (disk slot, e.g.
+	// "scsi0"), and Lifetime (in hours).
+	CreateOptions struct {
+		Name      string `url:"name"`
+		Partition string `url:"partition"`
+		Lifetime  int    `url:"lifetime"`
+	}
+
+	// SnapshotOptions identifies a snapshot for the operations
+	// that act on a single snapshot (delete, restore). The server
+	// is identified by Name; the snapshot by Snapshot.
+	SnapshotOptions struct {
+		Name     string `url:"name"`
+		Snapshot string `url:"snapshot"`
+	}
+
+	// SetLifetimeOptions describes a lifetime adjustment for an
+	// existing snapshot. Lifetime is in hours.
+	SetLifetimeOptions struct {
+		Name     string `url:"name"`
+		Snapshot string `url:"snapshot"`
+		Lifetime int    `url:"lifetime"`
+	}
+)

--- a/pkg/api/server/snapshot/response.go
+++ b/pkg/api/server/snapshot/response.go
@@ -1,0 +1,50 @@
+package snapshot
+
+import "github.com/sitehostnz/gosh/pkg/models"
+
+type (
+	// Snapshot describes a single server snapshot.
+	//
+	// Mixed value types reflect the API's actual response shape:
+	// most numeric / boolean fields are returned as strings ("0",
+	// "1") while Size is a JSON number and IsMissing is a real
+	// JSON bool. Pending is "1" while a job is in flight and "0"
+	// when stable.
+	Snapshot struct {
+		ID            string `json:"id"`
+		Name          string `json:"name"`
+		Device        string `json:"device"`
+		MountPoint    string `json:"mountpoint"`
+		Size          int64  `json:"size"`
+		FSType        string `json:"fstype"`
+		DRBD          string `json:"drbd"`
+		Parent        string `json:"parent"`
+		Pending       string `json:"pending"`
+		Created       string `json:"created"`
+		Backup        string `json:"backup"`
+		DiskTotal     string `json:"disk_total"`
+		DiskUsed      string `json:"disk_used"`
+		InodesTotal   string `json:"inodes_total"`
+		InodesUsed    string `json:"inodes_used"`
+		StatsUpdated  string `json:"stats_updated"`
+		DiskWarn      string `json:"disk_warn"`
+		IsMissing     bool   `json:"is_missing"`
+		Expires       string `json:"expires"`
+	}
+
+	// ListResponse represents the response from list_all.
+	ListResponse struct {
+		Return []Snapshot `json:"return"`
+		models.APIResponse
+	}
+
+	// JobResponse is the shared response shape for write
+	// operations (create, delete, restore, set_lifetime). Each
+	// queues an asynchronous scheduler job.
+	JobResponse struct {
+		Return struct {
+			models.Job `json:"job"`
+		} `json:"return"`
+		models.APIResponse
+	}
+)

--- a/pkg/api/server/snapshot/response.go
+++ b/pkg/api/server/snapshot/response.go
@@ -11,25 +11,25 @@ type (
 	// JSON bool. Pending is "1" while a job is in flight and "0"
 	// when stable.
 	Snapshot struct {
-		ID            string `json:"id"`
-		Name          string `json:"name"`
-		Device        string `json:"device"`
-		MountPoint    string `json:"mountpoint"`
-		Size          int64  `json:"size"`
-		FSType        string `json:"fstype"`
-		DRBD          string `json:"drbd"`
-		Parent        string `json:"parent"`
-		Pending       string `json:"pending"`
-		Created       string `json:"created"`
-		Backup        string `json:"backup"`
-		DiskTotal     string `json:"disk_total"`
-		DiskUsed      string `json:"disk_used"`
-		InodesTotal   string `json:"inodes_total"`
-		InodesUsed    string `json:"inodes_used"`
-		StatsUpdated  string `json:"stats_updated"`
-		DiskWarn      string `json:"disk_warn"`
-		IsMissing     bool   `json:"is_missing"`
-		Expires       string `json:"expires"`
+		ID           string `json:"id"`
+		Name         string `json:"name"`
+		Device       string `json:"device"`
+		MountPoint   string `json:"mountpoint"`
+		Size         int64  `json:"size"`
+		FSType       string `json:"fstype"`
+		DRBD         string `json:"drbd"`
+		Parent       string `json:"parent"`
+		Pending      string `json:"pending"`
+		Created      string `json:"created"`
+		Backup       string `json:"backup"`
+		DiskTotal    string `json:"disk_total"`
+		DiskUsed     string `json:"disk_used"`
+		InodesTotal  string `json:"inodes_total"`
+		InodesUsed   string `json:"inodes_used"`
+		StatsUpdated string `json:"stats_updated"`
+		DiskWarn     string `json:"disk_warn"`
+		IsMissing    bool   `json:"is_missing"`
+		Expires      string `json:"expires"`
 	}
 
 	// ListResponse represents the response from list_all.

--- a/pkg/api/server/snapshot/restore.go
+++ b/pkg/api/server/snapshot/restore.go
@@ -1,0 +1,45 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// Restore restores a server to a previous snapshot via
+// "server/snapshot/restore.json". Both Name (the server) and
+// Snapshot (the snapshot ID) are required.
+//
+// **This is destructive.** The server's disk state is reverted
+// to the snapshot's contents. Any data written since the
+// snapshot was taken will be lost. Treat as a write-mode
+// operation requiring deliberate caller intent.
+func (s *Client) Restore(ctx context.Context, opt SnapshotOptions) (response JobResponse, err error) {
+	if opt.Name == "" {
+		return response, fmt.Errorf("snapshot.Restore: Name is required")
+	}
+	if opt.Snapshot == "" {
+		return response, fmt.Errorf("snapshot.Restore: Snapshot is required")
+	}
+
+	u := "server/snapshot/restore.json"
+
+	keys := []string{"client_id", "name", "snapshot"}
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("name", opt.Name)
+	values.Add("snapshot", opt.Snapshot)
+
+	req, err := s.client.NewRequest("POST", u, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/server/snapshot/restore_test.go
+++ b/pkg/api/server/snapshot/restore_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestRestore_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/server/snapshot/restore.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -34,6 +35,7 @@ func TestRestore_Success(t *testing.T) {
 }
 
 func TestRestore_RequiredFields(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	if _, err := New(c).Restore(context.Background(), SnapshotOptions{}); err == nil ||
 		!strings.Contains(err.Error(), "Name is required") {

--- a/pkg/api/server/snapshot/restore_test.go
+++ b/pkg/api/server/snapshot/restore_test.go
@@ -1,0 +1,42 @@
+package snapshot
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestRestore_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/server/snapshot/restore.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("snapshot"); got != "91695" {
+			t.Errorf("snapshot = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":1,"type":"scheduler"}}}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	if _, err := New(c).Restore(context.Background(), SnapshotOptions{Name: "ch-foo", Snapshot: "91695"}); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+}
+
+func TestRestore_RequiredFields(t *testing.T) {
+	c, _ := api.New("k", "1")
+	if _, err := New(c).Restore(context.Background(), SnapshotOptions{}); err == nil ||
+		!strings.Contains(err.Error(), "Name is required") {
+		t.Errorf("err = %v", err)
+	}
+}

--- a/pkg/api/server/snapshot/setlifetime.go
+++ b/pkg/api/server/snapshot/setlifetime.go
@@ -1,0 +1,46 @@
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// SetLifetime adjusts the retention period of an existing
+// snapshot via "server/snapshot/set_lifetime.json". All three
+// fields are required: Name (the server), Snapshot (the
+// snapshot ID), Lifetime (hours).
+func (s *Client) SetLifetime(ctx context.Context, opt SetLifetimeOptions) (response JobResponse, err error) {
+	if opt.Name == "" {
+		return response, fmt.Errorf("snapshot.SetLifetime: Name is required")
+	}
+	if opt.Snapshot == "" {
+		return response, fmt.Errorf("snapshot.SetLifetime: Snapshot is required")
+	}
+	if opt.Lifetime <= 0 {
+		return response, fmt.Errorf("snapshot.SetLifetime: Lifetime must be > 0")
+	}
+
+	u := "server/snapshot/set_lifetime.json"
+
+	keys := []string{"client_id", "name", "snapshot", "lifetime"}
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("name", opt.Name)
+	values.Add("snapshot", opt.Snapshot)
+	values.Add("lifetime", strconv.Itoa(opt.Lifetime))
+
+	req, err := s.client.NewRequest("POST", u, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/pkg/api/server/snapshot/setlifetime_test.go
+++ b/pkg/api/server/snapshot/setlifetime_test.go
@@ -1,0 +1,52 @@
+package snapshot
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestSetLifetime_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("snapshot"); got != "91695" {
+			t.Errorf("snapshot = %q", got)
+		}
+		if got := r.Form.Get("lifetime"); got != "48" {
+			t.Errorf("lifetime = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":1,"type":"scheduler"}}}`)
+	}))
+	defer server.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(server.URL))
+	if _, err := New(c).SetLifetime(context.Background(), SetLifetimeOptions{
+		Name: "ch-foo", Snapshot: "91695", Lifetime: 48,
+	}); err != nil {
+		t.Fatalf("SetLifetime: %v", err)
+	}
+}
+
+func TestSetLifetime_RequiredFields(t *testing.T) {
+	c, _ := api.New("k", "1")
+	if _, err := New(c).SetLifetime(context.Background(), SetLifetimeOptions{Snapshot: "1", Lifetime: 1}); err == nil ||
+		!strings.Contains(err.Error(), "Name is required") {
+		t.Errorf("missing Name: err = %v", err)
+	}
+	if _, err := New(c).SetLifetime(context.Background(), SetLifetimeOptions{Name: "n", Lifetime: 1}); err == nil ||
+		!strings.Contains(err.Error(), "Snapshot is required") {
+		t.Errorf("missing Snapshot: err = %v", err)
+	}
+	if _, err := New(c).SetLifetime(context.Background(), SetLifetimeOptions{Name: "n", Snapshot: "1"}); err == nil ||
+		!strings.Contains(err.Error(), "Lifetime must be > 0") {
+		t.Errorf("missing Lifetime: err = %v", err)
+	}
+}

--- a/pkg/api/server/snapshot/setlifetime_test.go
+++ b/pkg/api/server/snapshot/setlifetime_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestSetLifetime_Success(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			t.Fatalf("ParseForm: %v", err)
@@ -36,6 +37,7 @@ func TestSetLifetime_Success(t *testing.T) {
 }
 
 func TestSetLifetime_RequiredFields(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	if _, err := New(c).SetLifetime(context.Background(), SetLifetimeOptions{Snapshot: "1", Lifetime: 1}); err == nil ||
 		!strings.Contains(err.Error(), "Name is required") {

--- a/pkg/api/server/upgradecomponents.go
+++ b/pkg/api/server/upgradecomponents.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"context"
+	"net/url"
+	"strconv"
+
+	"github.com/sitehostnz/gosh/pkg/net"
+)
+
+// UpgradeComponents upgrades specific hardware components (cores
+// and/or RAM) on a server via /server/upgrade.json. Returns a
+// scheduler job plus per-component bool flags indicating which
+// upgrades were accepted.
+//
+// At least one of Cores or RAM should be set; passing zero for both
+// is accepted by the API but is a no-op.
+//
+// Naming note: this wraps /server/upgrade.json (component upgrade).
+// The existing server.Upgrade method historically wraps
+// /server/upgrade_plan.json (plan / product-code upgrade) — its name
+// predates this wrapper, retained for backwards compatibility.
+//
+// **Live finding** (May 2026): the API rejects component upgrades
+// against CCS products (CLDCON4-P tested) with "Please specify a
+// valid cores value." — these products have fixed cores/RAM tied
+// to the product code; component-level scaling appears to be a
+// VPS-only operation. Use server.Upgrade (plan / product-code
+// upgrade) for CCS resizing instead.
+func (s *Client) UpgradeComponents(ctx context.Context, request UpgradeComponentsRequest) (response UpgradeComponentsResponse, err error) {
+	u := "server/upgrade.json"
+	keys := []string{"client_id", "name"}
+
+	values := url.Values{}
+	values.Add("client_id", s.client.ClientID)
+	values.Add("name", request.Name)
+	if request.Cores > 0 {
+		values.Add("upgrade[cores]", strconv.Itoa(request.Cores))
+		keys = append(keys, "upgrade[cores]")
+	}
+	if request.RAM != "" {
+		values.Add("upgrade[ram]", request.RAM)
+		keys = append(keys, "upgrade[ram]")
+	}
+	for label, sz := range request.Disk {
+		k := "upgrade[disk][" + label + "]"
+		values.Add(k, strconv.Itoa(sz))
+		keys = append(keys, k)
+	}
+
+	req, err := s.client.NewRequest("POST", u, net.Encode(values, keys))
+	if err != nil {
+		return response, err
+	}
+	if err := s.client.Do(ctx, req, &response); err != nil {
+		return response, err
+	}
+	return response, nil
+}

--- a/pkg/api/server/upgradecomponents_test.go
+++ b/pkg/api/server/upgradecomponents_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func TestUpgradeComponents_BothFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/server/upgrade.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		v, _ := url.ParseQuery(string(body))
+		if v.Get("name") != "myserver" {
+			t.Errorf("name = %q", v.Get("name"))
+		}
+		if v.Get("upgrade[cores]") != "4" || v.Get("upgrade[ram]") != "8" {
+			t.Errorf("upgrade fields = %v", v)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"status":true,"msg":"Successful",
+			"return":{"job":{"type":"scheduler","id":7355939},"cores":true,"ram":true}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	got, err := New(c).UpgradeComponents(context.Background(), UpgradeComponentsRequest{
+		Name: "myserver", Cores: 4, RAM: "8",
+	})
+	if err != nil {
+		t.Fatalf("UpgradeComponents: %v", err)
+	}
+	if !got.Return.Cores || !got.Return.RAM {
+		t.Errorf("expected both cores+ram accepted, got %+v", got.Return)
+	}
+	if got.Return.ID != 7355939 {
+		t.Errorf("Job.ID = %d", got.Return.ID)
+	}
+}
+
+func TestUpgradeComponents_DiskByLabel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		v, _ := url.ParseQuery(string(body))
+		if v.Get("upgrade[disk][xvda1]") != "80" {
+			t.Errorf("upgrade[disk][xvda1] = %q (want 80)", v.Get("upgrade[disk][xvda1]"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"job":{"id":1,"type":"scheduler"},"disk":true}}`)
+	}))
+	defer srv.Close()
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).UpgradeComponents(context.Background(), UpgradeComponentsRequest{
+		Name: "s1", Disk: map[string]int{"xvda1": 80},
+	}); err != nil {
+		t.Fatalf("UpgradeComponents: %v", err)
+	}
+}
+
+func TestUpgradeComponents_OmitsZeroFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		v, _ := url.ParseQuery(string(body))
+		if _, present := v["upgrade[cores]"]; present {
+			t.Errorf("upgrade[cores] should be omitted when 0, got %v", v)
+		}
+		if v.Get("upgrade[ram]") != "16" {
+			t.Errorf("upgrade[ram] = %q", v.Get("upgrade[ram]"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"OK","return":{"job":{"id":1,"type":"scheduler"},"ram":true}}`)
+	}))
+	defer srv.Close()
+
+	c, _ := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if _, err := New(c).UpgradeComponents(context.Background(), UpgradeComponentsRequest{
+		Name: "s1", RAM: "16",
+	}); err != nil {
+		t.Fatalf("UpgradeComponents: %v", err)
+	}
+}

--- a/pkg/api/server/upgradecomponents_test.go
+++ b/pkg/api/server/upgradecomponents_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestUpgradeComponents_BothFields(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/server/upgrade.json" {
 			t.Errorf("path = %q", r.URL.Path)
@@ -48,6 +49,7 @@ func TestUpgradeComponents_BothFields(t *testing.T) {
 }
 
 func TestUpgradeComponents_DiskByLabel(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		v, _ := url.ParseQuery(string(body))
@@ -67,6 +69,7 @@ func TestUpgradeComponents_DiskByLabel(t *testing.T) {
 }
 
 func TestUpgradeComponents_OmitsZeroFields(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		v, _ := url.ParseQuery(string(body))

--- a/pkg/api/server/writes_test.go
+++ b/pkg/api/server/writes_test.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sitehostnz/gosh/pkg/api"
+)
+
+func mockClient(t *testing.T, h http.HandlerFunc) (*api.Client, func()) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	c, err := api.New("k", "1", api.SetBaseURL(srv.URL))
+	if err != nil {
+		srv.Close()
+		t.Fatalf("api.New: %v", err)
+	}
+	return c, srv.Close
+}
+
+func TestAddIP_Success(t *testing.T) {
+	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/server/add_ip.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = r.ParseForm()
+		if got := r.Form.Get("param"); got != "192.0.2.10" {
+			t.Errorf("param = %q (note: add_ip uses 'param', not 'address')", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":1,"type":"scheduler"},"ip_addr":"192.0.2.10"}}`)
+	})
+	defer done()
+
+	got, err := New(c).AddIP(context.Background(), AddIPOptions{Name: "ch-foo", IP: "192.0.2.10"})
+	if err != nil {
+		t.Fatalf("AddIP: %v", err)
+	}
+	if got.Return.IPAddr != "192.0.2.10" {
+		t.Errorf("IPAddr = %q", got.Return.IPAddr)
+	}
+}
+
+func TestRemoveIP_Success(t *testing.T) {
+	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if got := r.Form.Get("address"); got != "192.0.2.10" {
+			t.Errorf("address = %q (note: remove_ip uses 'address', not 'param')", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":1,"type":"scheduler"},"ip_addr":"192.0.2.10"}}`)
+	})
+	defer done()
+
+	if _, err := New(c).RemoveIP(context.Background(), RemoveIPOptions{Name: "ch-foo", IP: "192.0.2.10"}); err != nil {
+		t.Fatalf("RemoveIP: %v", err)
+	}
+}
+
+func TestSetPrimaryIP_Success(t *testing.T) {
+	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if got := r.Form.Get("address"); got != "192.0.2.10" {
+			t.Errorf("address = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"ip_addr":"192.0.2.10"}}`)
+	})
+	defer done()
+
+	got, err := New(c).SetPrimaryIP(context.Background(), SetPrimaryIPOptions{Name: "ch-foo", IP: "192.0.2.10"})
+	if err != nil {
+		t.Fatalf("SetPrimaryIP: %v", err)
+	}
+	if got.Return.IPAddr != "192.0.2.10" {
+		t.Errorf("IPAddr = %q", got.Return.IPAddr)
+	}
+}
+
+func TestChangeState_Success(t *testing.T) {
+	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if got := r.Form.Get("state"); got != StatePowerOn {
+			t.Errorf("state = %q, want power_on", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":1,"type":"scheduler"}}}`)
+	})
+	defer done()
+
+	if _, err := New(c).ChangeState(context.Background(), ChangeStateOptions{Name: "ch-foo", State: StatePowerOn}); err != nil {
+		t.Fatalf("ChangeState: %v", err)
+	}
+}
+
+func TestCanProvision_Success(t *testing.T) {
+	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if got := r.Form.Get("product"); got != "XENLIT" {
+			t.Errorf("product = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful."}`)
+	})
+	defer done()
+
+	got, err := New(c).CanProvision(context.Background(), CanProvisionOptions{
+		Product: "XENLIT", Location: "AKLCITY", Distro: "ubuntu",
+	})
+	if err != nil {
+		t.Fatalf("CanProvision: %v", err)
+	}
+	if !got.Status {
+		t.Errorf("Status = false")
+	}
+}
+
+func TestServerWrites_RequiredFields(t *testing.T) {
+	c, _ := api.New("k", "1")
+	if _, err := New(c).AddIP(context.Background(), AddIPOptions{IP: "1.2.3.4"}); err == nil ||
+		!strings.Contains(err.Error(), "Name is required") {
+		t.Errorf("AddIP missing Name: %v", err)
+	}
+	if _, err := New(c).RemoveIP(context.Background(), RemoveIPOptions{Name: "n"}); err == nil ||
+		!strings.Contains(err.Error(), "IP is required") {
+		t.Errorf("RemoveIP missing IP: %v", err)
+	}
+	if _, err := New(c).ChangeState(context.Background(), ChangeStateOptions{Name: "n"}); err == nil ||
+		!strings.Contains(err.Error(), "State is required") {
+		t.Errorf("ChangeState missing State: %v", err)
+	}
+	if _, err := New(c).CanProvision(context.Background(), CanProvisionOptions{Location: "L", Distro: "d"}); err == nil ||
+		!strings.Contains(err.Error(), "Product is required") {
+		t.Errorf("CanProvision missing Product: %v", err)
+	}
+}

--- a/pkg/api/server/writes_test.go
+++ b/pkg/api/server/writes_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/sitehostnz/gosh/pkg/api"
 )
 
+const testIP = "192.0.2.10"
+
 func mockClient(t *testing.T, h http.HandlerFunc) (*api.Client, func()) {
 	t.Helper()
 	srv := httptest.NewServer(h)
@@ -23,12 +25,13 @@ func mockClient(t *testing.T, h http.HandlerFunc) (*api.Client, func()) {
 }
 
 func TestAddIP_Success(t *testing.T) {
+	t.Parallel()
 	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/server/add_ip.json" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
 		_ = r.ParseForm()
-		if got := r.Form.Get("param"); got != "192.0.2.10" {
+		if got := r.Form.Get("param"); got != testIP {
 			t.Errorf("param = %q (note: add_ip uses 'param', not 'address')", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -36,19 +39,20 @@ func TestAddIP_Success(t *testing.T) {
 	})
 	defer done()
 
-	got, err := New(c).AddIP(context.Background(), AddIPOptions{Name: "ch-foo", IP: "192.0.2.10"})
+	got, err := New(c).AddIP(context.Background(), AddIPOptions{Name: "ch-foo", IP: testIP})
 	if err != nil {
 		t.Fatalf("AddIP: %v", err)
 	}
-	if got.Return.IPAddr != "192.0.2.10" {
+	if got.Return.IPAddr != testIP {
 		t.Errorf("IPAddr = %q", got.Return.IPAddr)
 	}
 }
 
 func TestRemoveIP_Success(t *testing.T) {
+	t.Parallel()
 	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
-		if got := r.Form.Get("address"); got != "192.0.2.10" {
+		if got := r.Form.Get("address"); got != testIP {
 			t.Errorf("address = %q (note: remove_ip uses 'address', not 'param')", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -56,15 +60,16 @@ func TestRemoveIP_Success(t *testing.T) {
 	})
 	defer done()
 
-	if _, err := New(c).RemoveIP(context.Background(), RemoveIPOptions{Name: "ch-foo", IP: "192.0.2.10"}); err != nil {
+	if _, err := New(c).RemoveIP(context.Background(), RemoveIPOptions{Name: "ch-foo", IP: testIP}); err != nil {
 		t.Fatalf("RemoveIP: %v", err)
 	}
 }
 
 func TestSetPrimaryIP_Success(t *testing.T) {
+	t.Parallel()
 	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
-		if got := r.Form.Get("address"); got != "192.0.2.10" {
+		if got := r.Form.Get("address"); got != testIP {
 			t.Errorf("address = %q", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -72,16 +77,17 @@ func TestSetPrimaryIP_Success(t *testing.T) {
 	})
 	defer done()
 
-	got, err := New(c).SetPrimaryIP(context.Background(), SetPrimaryIPOptions{Name: "ch-foo", IP: "192.0.2.10"})
+	got, err := New(c).SetPrimaryIP(context.Background(), SetPrimaryIPOptions{Name: "ch-foo", IP: testIP})
 	if err != nil {
 		t.Fatalf("SetPrimaryIP: %v", err)
 	}
-	if got.Return.IPAddr != "192.0.2.10" {
+	if got.Return.IPAddr != testIP {
 		t.Errorf("IPAddr = %q", got.Return.IPAddr)
 	}
 }
 
 func TestChangeState_Success(t *testing.T) {
+	t.Parallel()
 	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
 		if got := r.Form.Get("state"); got != StatePowerOn {
@@ -98,6 +104,7 @@ func TestChangeState_Success(t *testing.T) {
 }
 
 func TestCanProvision_Success(t *testing.T) {
+	t.Parallel()
 	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
 		if got := r.Form.Get("product"); got != "XENLIT" {
@@ -120,6 +127,7 @@ func TestCanProvision_Success(t *testing.T) {
 }
 
 func TestServerWrites_RequiredFields(t *testing.T) {
+	t.Parallel()
 	c, _ := api.New("k", "1")
 	if _, err := New(c).AddIP(context.Background(), AddIPOptions{IP: "1.2.3.4"}); err == nil ||
 		!strings.Contains(err.Error(), "Name is required") {

--- a/pkg/api/server/writes_test.go
+++ b/pkg/api/server/writes_test.go
@@ -48,6 +48,88 @@ func TestAddIP_Success(t *testing.T) {
 	}
 }
 
+// TestAddIP_AutoAllocateByVersion exercises the IPVersion path:
+// the wrapper sends `param=4` (or `=6`) so the API allocates a
+// fresh address from the family pool. Live evidence: this is how
+// add_ip's auto-allocation actually works (see [AddIPOptions]).
+func TestAddIP_AutoAllocateByVersion(t *testing.T) {
+	t.Parallel()
+	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if got := r.Form.Get("param"); got != "4" {
+			t.Errorf("param = %q, want \"4\" (family number)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":1,"type":"scheduler"},"ip_addr":"203.0.113.21"}}`)
+	})
+	defer done()
+	if _, err := New(c).AddIP(context.Background(), AddIPOptions{Name: "ch-foo", IPVersion: 4}); err != nil {
+		t.Fatalf("AddIP: %v", err)
+	}
+}
+
+func TestAddIP_RejectsNeitherIPNorVersion(t *testing.T) {
+	t.Parallel()
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	_, err := New(c).AddIP(context.Background(), AddIPOptions{Name: "ch-foo"})
+	if err == nil || !strings.Contains(err.Error(), "exactly one of") {
+		t.Errorf("expected exactly-one-of error, got: %v", err)
+	}
+}
+
+func TestAddIP_RejectsBothIPAndVersion(t *testing.T) {
+	t.Parallel()
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	_, err := New(c).AddIP(context.Background(), AddIPOptions{Name: "ch-foo", IP: testIP, IPVersion: 4})
+	if err == nil || !strings.Contains(err.Error(), "exactly one of") {
+		t.Errorf("expected exactly-one-of error, got: %v", err)
+	}
+}
+
+func TestAddIP_RejectsBadIPVersion(t *testing.T) {
+	t.Parallel()
+	c, _ := api.New("k", "1", api.SetBaseURL("http://example.invalid"))
+	_, err := New(c).AddIP(context.Background(), AddIPOptions{Name: "ch-foo", IPVersion: 5})
+	if err == nil || !strings.Contains(err.Error(), "must be 4 or 6") {
+		t.Errorf("expected family-number error, got: %v", err)
+	}
+}
+
+// TestDelete_ForceFlag locks down DeleteRequest.Force=true emitting
+// `force_delete=1` in the form body, required for tearing down a
+// fresh CCS that still has its auto-deployed infra stack present.
+func TestDelete_ForceFlag(t *testing.T) {
+	t.Parallel()
+	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if got := r.Form.Get("force_delete"); got != "1" {
+			t.Errorf("force_delete = %q, want \"1\"", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":1,"type":"scheduler"}}}`)
+	})
+	defer done()
+	if _, err := New(c).Delete(context.Background(), DeleteRequest{Name: "ch-foo", Force: true}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestDelete_NoForceFlagByDefault(t *testing.T) {
+	t.Parallel()
+	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if _, present := r.Form["force_delete"]; present {
+			t.Errorf("force_delete should not be present when Force=false; got %q", r.Form.Get("force_delete"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"status":true,"msg":"Successful","return":{"job":{"id":1,"type":"scheduler"}}}`)
+	})
+	defer done()
+	if _, err := New(c).Delete(context.Background(), DeleteRequest{Name: "ch-foo"}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
 func TestRemoveIP_Success(t *testing.T) {
 	t.Parallel()
 	c, done := mockClient(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
**Depends on #45.** Stacked on \`feat/server\` so the diff against \`main\` shows both PRs together; once #45 merges this branch can be rebased onto main and the PR will narrow to just the follow-up commit.

Two deferred follow-ups from the #45 approval review.

## 1. AddIP IP/IPVersion typed options

The reviewer's live probe established two distinct conventions on \`/server/add_ip.json\`:

| Probe | Result |
|---|---|
| \`AddIP{IP:"auto"}\` | rejected — "The ip address is invalid, please specify a valid ip address" |
| \`AddIP{IP:"203.0.113.5"}\` | allocates the explicit address |
| \`AddIP{IP:"4"}\` | auto-allocates an IPv4 from the pool |
| \`AddIP{IP:"6"}\` | auto-allocates an IPv6 from the pool |

The magic-string \`"4"\` / \`"6"\` is awkward to expose. This PR splits \`AddIPOptions\` into:

\`\`\`go
AddIPOptions struct {
    Name      string
    IP        string  // explicit address (mutually exclusive with IPVersion)
    IPVersion int     // 4 or 6 to auto-allocate (mutually exclusive with IP)
}
\`\`\`

Set exactly one of \`IP\` or \`IPVersion\`. The wrapper assembles the wire-level \`param\` field internally. Up-front validation rejects both-set, neither-set, and \`IPVersion ∉ {4,6}\`.

Backward-compat: existing call sites passing \`AddIPOptions{IP: "..."}\` keep working unchanged.

## 2. DeleteRequest.Force

Adds \`Force bool\` to \`DeleteRequest\` and conditional \`force_delete=1\` form-body emission. Required to tear down a fresh CCS that still has its auto-deployed infra stack present (otherwise the API rejects with "the server has containers"). The \`delete.go\` doc comment reflects the new field.

## Tests

- AddIP with IPVersion → \`param=4\` lands on the wire
- AddIP{both} → exactly-one-of error
- AddIP{neither} → exactly-one-of error
- AddIP{IPVersion:5} → "must be 4 or 6"
- Delete{Force:true} → \`force_delete=1\` emitted
- Delete{} → \`force_delete\` absent

Existing \`TestAddIP_Success\` (explicit IP path) still passes unchanged.