### PR TITLE
chore: update CHANGELOG for the v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## [v0.7.0] - 2026-07-24
 ### Added
 - Support for SRS domain registry endpoints (lookup, lifecycle, contacts, nameservers, WHOIS, transfers, renewals).
 - Support for mail endpoints (domains, aliases, accounts, forwards) and a combined list view.


### PR DESCRIPTION
## Summary
Cuts the **v0.7.0** release by promoting the existing `[Unreleased]` changelog section to a dated release heading and opening a fresh `[Unreleased]` block.

No code changes - this is a release/changelog bookkeeping PR. The changes being released landed in `feat: expand API surface across packages` (7940b34).

## Changes
- Promote `[Unreleased]` → `[v0.7.0] - 2026-07-24` in `CHANGELOG.md`
- Add a new empty `[Unreleased]` section at the top

## Version rationale
Minor bump from v0.6.0: the release is dominated by new backward-compatible API surface (Added entries), consistent with semver for a 0.x library.

## Follow-up
After merge, tag the release:  `git tag v0.7.0 && git push origin v0.7.0`